### PR TITLE
Fixes reference to chart.min.css and chart.min.js in admin.handlebars

### DIFF
--- a/server/views/layouts/admin.handlebars
+++ b/server/views/layouts/admin.handlebars
@@ -23,7 +23,7 @@
   <link href="/node_modules/formiojs/dist/formio.form.min.css" rel="stylesheet">
   <link href="/admin/css/custom.css" rel="stylesheet">
   <link href="/vendors/dropzone/dropzone.min.css" rel="stylesheet">
-  <link href="/node_modules/chart.js/dist/chart.min.css" rel="stylesheet">
+  <link href="/node_modules/chart.js/dist/Chart.min.css" rel="stylesheet">
   <link href="/node_modules/datatables.net-bs4/css/dataTables.bootstrap4.min.css" rel="stylesheet">
   <link href="/node_modules/jstree/dist/themes/default/style.min.css" rel="stylesheet">
 
@@ -745,7 +745,7 @@
   <script src="/node_modules/perfect-scrollbar/dist/perfect-scrollbar.min.js"></script>
   <script src="/node_modules/@coreui/coreui/dist/js/coreui.min.js"></script>
   <script src="/node_modules/@coreui/coreui-plugin-chartjs-custom-tooltips/dist/js/custom-tooltips.min.js"></script>
-  <script src="/node_modules/chart.js/dist/chart.min.js"></script>
+  <script src="/node_modules/chart.js/dist/Chart.min.js"></script>
   <script src="/admin/js/charts.js"></script>
   <script src="/node_modules/formiojs/dist/formio.full.min.js"></script>
   <script src="/page-builder/js/page-builder.js"></script>


### PR DESCRIPTION
I was getting a file not found error for `chart.min.css` and `chart.min.js` so here's a tiny little fix for case-sensitive file systems.

Also what are your thoughts on using webpack/babel so we can use imports instead of require? I was looking into doing it for my local instance but if you're into the idea I can share the results for you to review.