### PR TITLE
allow connection to remote mysql database

### DIFF
--- a/server.js
+++ b/server.js
@@ -314,11 +314,12 @@ function main() {
   }
 
   if (process.env.TYPEORM_CONNECTION === "mysql") {
+    connectionSettings.host = process.env.TYPEORM_HOST;
+    connectionSettings.port = process.env.TYPEORM_PORT;
     connectionSettings.username = process.env.TYPEORM_USERNAME;
     connectionSettings.password = process.env.TYPEORM_PASSWORD;
-    connectionSettings.port = process.env.TYPEORM_PORT;
     connectionSettings.database = process.env.TYPEORM_DATABASE;
-    }
+  }
 
   typeorm.createConnection(connectionSettings).then((connection) => {
     console.log(logSymbols.success, "Successfully connected to Database!");

--- a/server.js
+++ b/server.js
@@ -98,6 +98,7 @@ function setupSessionDb(app) {
       saveUninitialized: false,
       store: new TypeormStore({
         cleanupLimit: 5,
+        limitSubquery: false, // If using MariaDB - see https://github.com/nykula/connect-typeorm/issues/8
         ttl: 86400 * sessionLengthDays,
       }).connect(sessionRepo),
     })


### PR DESCRIPTION
Added 

connectionSettings.port = process.env.TYPEORM_PORT; 

in server.js to allow remote mysql connection.