### PR TITLE
better filter for path traversal (CVE-2023-33690)

### DIFF
--- a/server/services/backup.service.js
+++ b/server/services/backup.service.js
@@ -31,8 +31,8 @@ module.exports = backUpService = {
       const file = `${appRoot.path}/${req.path}`;
 
       const path = resolve(file)
-      
-      if (!path.includes("backups")) {
+
+      if (!path.includes(`${appRoot.path}/backups`)) {
          console.log("Directory traversal detected...")
          res.redirect('/admin/backup-restore');
          return;


### PR DESCRIPTION
This is a better path traversal filter bypass by also ensuring that the absolute path of the file to be downloaded starts with the appRoot path.

This ensures that lane711/sonicjs all versions from 0.5.4 (where the backup service was first introduced) - 0.7.0 prior to the migration to headless version is not vulnerable to a path traversal, mainly caused by a user with administrative privileges, being able to control the file name of the backup to be downloaded, and that the user controlled file name input is not sanitised, which gives them the ability to read any file on the system as long as they know the path to it (local file inclusion vulnerability).