### PR TITLE
Wait for D1 database update to complete

### DIFF
--- a/src/cms/api/content.ts
+++ b/src/cms/api/content.ts
@@ -181,7 +181,7 @@ content.put("/", async (ctx) => {
   } finally {
     //then also save the content to sqlite for filtering, sorting, etc
     try {
-      const result = updateD1Data(ctx.env.D1DATA, content.table, content);
+      const result = await updateD1Data(ctx.env.D1DATA, content.table, content);
     } catch (error) {
       console.log("error posting content", error);
     }

--- a/src/cms/data/d1-data.test.ts
+++ b/src/cms/data/d1-data.test.ts
@@ -114,7 +114,7 @@ it("updateD1Data should update record", async () => {
     id: "b",
   });
 
-  updateD1Data(__D1_BETA__D1DATA, "users", {
+  await updateD1Data(__D1_BETA__D1DATA, "users", {
     data: { firstName: "Steve" },
     id: "b",
   });

--- a/src/cms/data/data.ts
+++ b/src/cms/data/data.ts
@@ -342,7 +342,7 @@ export async function updateRecord(d1, kv, data) {
   } finally {
     //then also save the content to sqlite for filtering, sorting, etc
     try {
-      const result = updateD1Data(d1, data.table, data);
+      const result = await updateD1Data(d1, data.table, data);
       //expire cache
       await setCacheStatusInvalid();
       await clearKVCache(kv);


### PR DESCRIPTION
Closes https://github.com/lane711/sonicjs/issues/217

In order for the D1 database update to always complete, we need to await the update Promise or pass the Promise to `waitUntil()`, so that the runtime dos not prematurely terminate the update.

I don't think the local wrangler runtime terminates code as aggressively as the actual CF Runtime, so the only place to check any change in behavior is on the actual CF Runtime. Therefore I'm not really sure what test I could add. (Also, I had trouble getting the test suite to run locally.) Let me know if you need anything else from me. Thanks!

