### PR TITLE
chore: Formatter settings and execution by GitHub Actions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.{js,mjs,cjs,jsx,ts,mts,cts,tsx,json,yaml,toml,css,html,md}]
+indent_style = space
+indent_size = 2

--- a/.github/workflows/static-analytics.yaml
+++ b/.github/workflows/static-analytics.yaml
@@ -1,0 +1,28 @@
+name: Static Analytics
+
+on:
+  workflow_dispatch:
+  push:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  static-analytics:
+    runs-on: ubuntu-22.04
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      
+      - name: Packages Install
+        run: npm ci
+
+      - name: Static Check
+        run: npm run check
+

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ dist
 .wrangler/state
 .wrangler/tmp
 wrangler.toml
-.vscode/settings.json
+

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+migrations/
+*.md

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,8 @@
+{
+    "recommendations": [
+        "esbenp.prettier-vscode",
+        "davidanson.vscode-markdownlint",
+        "editorconfig.editorconfig"
+    ]
+}
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "editor.defaultFormatter": "esbenp.prettier-vscode",
+    "[markdown]": {
+        "editor.defaultFormatter": "DavidAnson.vscode-markdownlint"
+    }
+}
+

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "up:prod": "wrangler d1 migrations apply sonicjs",
     "tail": "wrangler pages deployment tail",
     "check": "run-p check:*",
-    "check:prettier": "prettier --check --cache . **/*.css !**/*.md",
+    "check:prettier": "prettier --check --cache . **/*.css",
     "fix": "run-s fix:*",
-    "fix:prettier": "prettier --write --cache . **/*.css !**/*.md"
+    "fix:prettier": "prettier --write --cache . **/*.css"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,11 @@
     "generate": "drizzle-kit generate:sqlite --schema=./src/db/schema --out=./migrations",
     "up": "wrangler d1 migrations apply sonicjs --local",
     "up:prod": "wrangler d1 migrations apply sonicjs",
-    "tail": "wrangler pages deployment tail"
+    "tail": "wrangler pages deployment tail",
+    "check": "run-p check:*",
+    "check:prettier": "prettier --check --cache . **/*.css !**/*.md",
+    "fix": "run-s fix:*",
+    "fix:prettier": "prettier --write --cache . **/*.css !**/*.md"
   },
   "keywords": [],
   "author": "",
@@ -52,3 +56,4 @@
     "uuid": "^9.0.0"
   }
 }
+


### PR DESCRIPTION
# Overview

Prettier is currently included in the dependencies.
However, there was no evidence of actual use, and it seemed that the proper configuration did not exist.

To me, this project is very attractive.
However, I find it difficult to contribute due to the lack of an organized development environment.

In the future, I would like to add Linter and, if possible, unify the tool chain with Biome and others.
However, to do this all together at once would be fraught with difficulties.

As a first step, why not introduce Prettier and format the entire project code?
This should not be a problem in most cases.

# Items to consider

- Prettier
  - The default settings are used during the creation phase of the PR.
  - I personally prefer `semi :false` (default `semi: true` for PR creation phase).
- editorconfig
  - No special settings are used, but there may be some extension omissions.
- VSCode
  - So far it has been excluded from Git management, is there any reason for this?
  - If there is a reason why `.vscode/settings.json` cannot be used, we will use the Workspace feature.
    - https://code.visualstudio.com/docs/editor/workspaces 
  - Only Markdown uses an editor-dependent formatter
    - This is because CJK is prone to problems
- GitHub Actions
  - Only minimal settings are used.
  - Node.js version is the latest v20 as it was not specified.
  - As long as the repository is public, it can be operated for free.

# Remaining work

- As soon as we get the OK, we'll add a commit with the whole thing formatted.
  - Not done at this time to avoid conflicts.
  - applied my fork repository https://github.com/totto2727-org/lapriere-cms/pull/1
 
# Related PR

https://github.com/lane711/sonicjs/pull/115

The author is not good at English and uses Deepl translation.
Sorry if there are any points that are difficult to understand.