### PR TITLE
Correct licensing information

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Lane C. (https://github.com/lane711) and SonicJS contributors (https://github.com/lane711/sonicjs/graphs/contributors)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "fix:prettier": "prettier --write --cache . **/*.css"
   },
   "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "author": "Lane C.",
+  "license": "MIT",
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20240208.0",
     "@types/jest": "^29.5.12",


### PR DESCRIPTION
According to the [SonicJS official website](https://sonicjs.com/#licensing), SonicJS is licensed under MIT license.
However, there were no LICENSE.\* files in this repository and the `license` field of package.json is "ISC" (I guess ISC is the wrong license).
This PR adds LICENSE.txt for formal licensing and corrects `license` field of package.json to avoid misunderstanding.

When you merge this PR, please use "Rebase and merge" so that the commits will be GPG-verified to guarantee that the commit is merged by your decision.
Because I forked this repository, I want to avoid being suspected I changed the license documents without the copyright holders' permission even if the sonicjs.com website and this repository were deleted in the future.

I do not claim any copyrights for the changes I made in this Pull Request.