### PR TITLE
feat: allow running in local d1 & kv

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Run the `npx wrangler whoami` command and copy the "Account ID" below
+CLOUDFLARE_ACCOUNT_ID=
+
+# Run the `npx wrangler pages project list` command and copy the "Project Name" below
+CLOUDFLARE_PROJECT_NAME=
+
+# Run the `npx wrangler kv namespace list` command and copy the "id" below
+CLOUDFLARE_KV_ID=
+CLOUDFLARE_KV_PREVIEW_ID=
+
+# Run the `npx wrangler d1 list` command and copy the "uuid" below
+CLOUDFLARE_D1_ID=
+CLOUDFLARE_D1_PREVIEW_ID=

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,48 @@
+name: Deploy to Cloudflare Pages
+
+on:
+  # push:
+  #  branches: ["main"]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+    inputs:
+      DEPLOYMENT_ENVIRONMENT:
+        description: "Deployment environment"
+        required: true
+        type: choice
+        options:
+          - preview
+          - production
+        default: "production"
+
+env:
+  # Variables
+  CLOUDFLARE_ACCOUNT_ID: ${{ vars.CLOUDFLARE_ACCOUNT_ID }}
+  CLOUDFLARE_PROJECT_NAME: ${{ vars.CLOUDFLARE_PROJECT_NAME }}
+  CLOUDFLARE_KV_ID: ${{ vars.CLOUDFLARE_KV_ID }}
+  CLOUDFLARE_KV_PREVIEW_ID: ${{ vars.CLOUDFLARE_KV_PREVIEW_ID }}
+  CLOUDFLARE_D1_ID: ${{ vars.CLOUDFLARE_D1_ID }}
+  CLOUDFLARE_D1_PREVIEW_ID: ${{ vars.CLOUDFLARE_D1_PREVIEW_ID }}
+  # Secrets
+  CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.event.inputs.DEPLOYMENT_ENVIRONMENT }}
+    steps:
+      - name: 🛎 Checkout
+        uses: actions/checkout@v4
+      - name: 🏗 Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x
+          cache: "npm"
+      - name: 📦 Install dependencies
+        run: npm ci
+      - name: ⛑ Build
+        run: npm run build
+      - name: 🚀 Deploy to Cloudflare Pages [${{ inputs.DEPLOYMENT_ENVIRONMENT }}]
+        run: npm run deploy

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ TEMP.md
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+# Deployment config
+wrangler.deploy.jsonc

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,11 +5,12 @@ import tailwind from "@astrojs/tailwind";
 
 import react from "@astrojs/react";
 
+import genConfig from "./scripts/gen-conf.integration.mjs";
 
 // https://astro.build/config
 export default defineConfig({
   output: "server",
-  integrations: [tailwind(), react()],
+  integrations: [tailwind(), react(), genConfig()],
   adapter: cloudflare({
     platformProxy: {
       enabled: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sonicjs",
-  "version": "0.1.6",
+  "version": "0.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sonicjs",
-      "version": "0.1.6",
+      "version": "0.2.1",
       "dependencies": {
         "@astrojs/check": "^0.9.3",
         "@astrojs/cloudflare": "^11.1.0",

--- a/package.json
+++ b/package.json
@@ -12,8 +12,9 @@
     "test:watch": "vitest",
     "e2e": "npx playwright test --ui",
     "generate": "drizzle-kit generate",
-    "up": "wrangler d1 migrations apply sonicjs --local",
-    "up:prod": "wrangler d1 migrations apply sonicjs  --remote"
+    "up": "wrangler d1 migrations apply sonicjs",
+    "up:prod": "wrangler d1 migrations apply sonicjs --remote -c wrangler.deploy.jsonc",
+    "deploy": "wrangler pages deploy"
   },
   "dependencies": {
     "@astrojs/check": "^0.9.3",

--- a/scripts/gen-conf.integration.mjs
+++ b/scripts/gen-conf.integration.mjs
@@ -1,0 +1,77 @@
+import { writeFileSync, mkdirSync } from "node:fs";
+import { dirname } from "node:path";
+import { loadEnv } from "vite";
+
+/**
+ * Generate deployment configuration files using environment variables.
+ *
+ * @returns {import('astro').AstroIntegration}
+ */
+export default function genConfig() {
+  return {
+    name: "gen-conf",
+    hooks: {
+      "astro:build:done": async () => {
+        console.log("⚡️ Loading environment variables...", process.cwd());
+        const {
+          CLOUDFLARE_PROJECT_NAME,
+          CLOUDFLARE_KV_ID,
+          CLOUDFLARE_KV_PREVIEW_ID,
+          CLOUDFLARE_D1_ID,
+          CLOUDFLARE_D1_PREVIEW_ID,
+        } = loadEnv(process.env.NODE_ENV, process.cwd(), "");
+
+        const missing = (name) =>
+          `⚠️ The environment variable ${name} is not set. This will cause your application to fail when deploying to Cloudflare.`;
+        if (!CLOUDFLARE_PROJECT_NAME)
+          console.warn(missing("CLOUDFLARE_PROJECT_NAME"));
+        if (!CLOUDFLARE_KV_ID) console.warn(missing("CLOUDFLARE_KV_ID"));
+        if (!CLOUDFLARE_D1_ID) console.warn(missing("CLOUDFLARE_D1_ID"));
+
+        // Config files to generate
+        const configs = {
+          // https://developers.cloudflare.com/workers/wrangler/configuration/#generated-wrangler-configuration
+          ".wrangler/deploy/config.json": {
+            configPath: "../../wrangler.deploy.jsonc",
+          },
+          // Deployment config targeting production.
+          // Please check `.env.example` file Make sure those env vars are correctly set.
+          "wrangler.deploy.jsonc": {
+            name: CLOUDFLARE_PROJECT_NAME,
+            pages_build_output_dir: "./dist",
+            compatibility_date: "2025-03-14",
+            compatibility_flags: ["nodejs_compat"],
+            kv_namespaces: [
+              {
+                binding: "KV",
+                id: CLOUDFLARE_KV_ID,
+                preview_id: CLOUDFLARE_KV_PREVIEW_ID,
+              },
+            ],
+            d1_databases: [
+              {
+                binding: "D1",
+                database_name: "sonicjs",
+                database_id: CLOUDFLARE_D1_ID,
+                preview_database_id: CLOUDFLARE_D1_PREVIEW_ID,
+                migrations_dir: "./migrations",
+              },
+            ],
+            vars: {
+              DISABLE_CACHE: true,
+            },
+          },
+        };
+
+        for (const [path, data] of Object.entries(configs)) {
+          console.log(`💾 Generating ${path}...`);
+          // Ensure the directory exists
+          mkdirSync(dirname(path), { recursive: true });
+          // Write the configs
+          writeFileSync(path, JSON.stringify(data, null, 2));
+        }
+        console.log("✅ Wrangler deployment config generated!");
+      },
+    },
+  };
+}


### PR DESCRIPTION
This change add a `dev` environment to allow running **sonicjs** in local without Cloudflare account.

The "Getting Started" section can be simplify as:

```sh
# Clone the repository & install deps
git clone https://github.com/lane711/sonicjs.git
cd sonicjs
npm install

# Apply the default database schema
npm run up

# Run the app
npm run dev
```

> Note: I have to update the `@astrojs/cloudflare` and `astro` package to latest version to support this. Hope you're intend to upgrade this anyway 😄