### PR TITLE
feat: create fresh D1 database for each PR and worktree

### DIFF
--- a/.github/CLAUDE_WORKFLOW.md
+++ b/.github/CLAUDE_WORKFLOW.md
@@ -5,10 +5,35 @@ This document outlines the workflow for using Claude in Conductor to fix GitHub 
 ## Workflow Overview
 
 1. **Start in Conductor** - Conductor automatically creates a worktree and branch
-2. **Claude fixes the issue** - Implement the fix with tests
-3. **Create PR** - Push changes and create pull request
-4. **CI runs tests** - GitHub Actions runs unit and E2E tests
-5. **Manual review** - You review and merge the PR
+2. **Setup fresh database** - Run `npm run setup:db` in my-sonicjs-app to create a clean D1 database
+3. **Claude fixes the issue** - Implement the fix with tests
+4. **Create PR** - Push changes and create pull request
+5. **CI runs tests** - GitHub Actions creates a fresh D1 database and runs unit/E2E tests
+6. **Manual review** - You review and merge the PR
+
+## Database Setup
+
+Each PR and worktree gets a fresh D1 database to ensure clean testing environments.
+
+### For Local Development (Worktrees)
+
+```bash
+cd my-sonicjs-app
+npm run setup:db
+```
+
+This script:
+- Creates a new D1 database named after your branch (e.g., `sonicjs-worktree-fix-auth-bug`)
+- Updates `wrangler.toml` with the new database ID
+- Runs all migrations against the fresh database
+
+### For PRs (Automatic)
+
+GitHub Actions automatically:
+- Creates a D1 database named `sonicjs-pr-<branch-name>`
+- Applies all migrations
+- Deploys the preview with the fresh database
+- Runs E2E tests against it
 
 ## Steps for Claude
 

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -37,6 +37,64 @@ jobs:
       - name: Build core package
         run: npm run build:core
 
+      - name: Create fresh D1 database for PR
+        id: create-db
+        run: |
+          cd my-sonicjs-app
+          BRANCH_NAME="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+          SAFE_BRANCH=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9-]/-/g' | cut -c1-50)
+          DB_NAME="sonicjs-pr-${SAFE_BRANCH}"
+
+          echo "Creating fresh D1 database: $DB_NAME"
+
+          # Check if database already exists
+          EXISTING_DB=$(npx wrangler d1 list --json | jq -r ".[] | select(.name == \"$DB_NAME\") | .uuid" 2>/dev/null || echo "")
+
+          if [ -n "$EXISTING_DB" ]; then
+            echo "Database $DB_NAME already exists with ID: $EXISTING_DB"
+            DB_ID="$EXISTING_DB"
+          else
+            # Create new database
+            CREATE_OUTPUT=$(npx wrangler d1 create "$DB_NAME" 2>&1)
+            echo "$CREATE_OUTPUT"
+
+            # Extract database ID from creation output
+            DB_ID=$(echo "$CREATE_OUTPUT" | grep -oP 'database_id\s*=\s*"\K[^"]+' || echo "")
+
+            if [ -z "$DB_ID" ]; then
+              # Try alternative extraction method
+              DB_ID=$(npx wrangler d1 list --json | jq -r ".[] | select(.name == \"$DB_NAME\") | .uuid")
+            fi
+          fi
+
+          if [ -z "$DB_ID" ]; then
+            echo "Error: Failed to get database ID"
+            exit 1
+          fi
+
+          echo "Database ID: $DB_ID"
+          echo "db_id=$DB_ID" >> $GITHUB_OUTPUT
+          echo "db_name=$DB_NAME" >> $GITHUB_OUTPUT
+
+          # Update wrangler.toml with the new database ID
+          sed -i "s/database_id = \"[^\"]*\"/database_id = \"$DB_ID\"/" wrangler.toml
+          sed -i "s/database_name = \"[^\"]*\"/database_name = \"$DB_NAME\"/" wrangler.toml
+
+          echo "Updated wrangler.toml with new database"
+          grep -A2 "d1_databases" wrangler.toml
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
+      - name: Run D1 migrations
+        run: |
+          cd my-sonicjs-app
+          echo "Applying migrations to database: ${{ steps.create-db.outputs.db_name }}"
+          npx wrangler d1 migrations apply ${{ steps.create-db.outputs.db_name }} --remote
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+
       - name: Deploy to Cloudflare Workers Preview
         id: deploy
         run: |
@@ -47,7 +105,7 @@ jobs:
 
           # Deploy and capture the URL (don't exit on error)
           set +e
-          echo "Deploying to preview environment: pr-${SAFE_BRANCH}"
+          echo "Deploying to preview environment: sonicjs-pr-${SAFE_BRANCH}"
           DEPLOY_OUTPUT=$(npx wrangler deploy --name "sonicjs-pr-${SAFE_BRANCH}" 2>&1)
           DEPLOY_EXIT_CODE=$?
           set -e

--- a/my-sonicjs-app/package.json
+++ b/my-sonicjs-app/package.json
@@ -19,7 +19,8 @@
     "test:watch": "vitest",
     "update": "npm install @sonicjs-cms/core@latest --save",
     "update:beta": "npm install @sonicjs-cms/core@beta --save",
-    "seed": "tsx scripts/seed-admin.ts"
+    "seed": "tsx scripts/seed-admin.ts",
+    "setup:db": "bash scripts/setup-worktree-db.sh"
   },
   "dependencies": {
     "@sonicjs-cms/core": "file:../packages/core"

--- a/my-sonicjs-app/scripts/setup-worktree-db.sh
+++ b/my-sonicjs-app/scripts/setup-worktree-db.sh
@@ -1,0 +1,96 @@
+#!/bin/bash
+
+# Setup a fresh D1 database for this worktree
+# This script creates a new D1 database named after the current git branch
+# and updates wrangler.toml to use it
+
+set -e
+
+# Get the current branch name
+BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
+if [ -z "$BRANCH_NAME" ] || [ "$BRANCH_NAME" = "HEAD" ]; then
+  echo "Error: Could not determine branch name"
+  exit 1
+fi
+
+# Create a safe database name from branch
+SAFE_BRANCH=$(echo "$BRANCH_NAME" | sed 's/[^a-zA-Z0-9-]/-/g' | cut -c1-50)
+DB_NAME="sonicjs-worktree-${SAFE_BRANCH}"
+
+echo "Setting up fresh D1 database for worktree: $BRANCH_NAME"
+echo "Database name: $DB_NAME"
+
+# Change to my-sonicjs-app directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+# Check if database already exists
+echo "Checking for existing database..."
+EXISTING_DB=$(npx wrangler d1 list --json 2>/dev/null | jq -r ".[] | select(.name == \"$DB_NAME\") | .uuid" || echo "")
+
+if [ -n "$EXISTING_DB" ]; then
+  echo "Database $DB_NAME already exists with ID: $EXISTING_DB"
+  DB_ID="$EXISTING_DB"
+
+  # Ask if user wants to delete and recreate
+  read -p "Delete existing database and create fresh one? (y/N): " -n 1 -r
+  echo
+  if [[ $REPLY =~ ^[Yy]$ ]]; then
+    echo "Deleting existing database..."
+    npx wrangler d1 delete "$DB_NAME" --skip-confirmation
+    EXISTING_DB=""
+  fi
+fi
+
+if [ -z "$EXISTING_DB" ]; then
+  # Create new database
+  echo "Creating new D1 database: $DB_NAME"
+  CREATE_OUTPUT=$(npx wrangler d1 create "$DB_NAME" 2>&1)
+  echo "$CREATE_OUTPUT"
+
+  # Extract database ID from creation output
+  DB_ID=$(echo "$CREATE_OUTPUT" | grep -oE 'database_id\s*=\s*"[^"]+"' | grep -oE '"[^"]+"' | tr -d '"' || echo "")
+
+  if [ -z "$DB_ID" ]; then
+    # Try alternative extraction method
+    DB_ID=$(npx wrangler d1 list --json | jq -r ".[] | select(.name == \"$DB_NAME\") | .uuid")
+  fi
+fi
+
+if [ -z "$DB_ID" ]; then
+  echo "Error: Failed to get database ID"
+  exit 1
+fi
+
+echo "Database ID: $DB_ID"
+
+# Update wrangler.toml with the new database ID
+echo "Updating wrangler.toml..."
+
+# Use sed to replace database_id and database_name
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  # macOS sed requires empty string after -i
+  sed -i '' "s/database_id = \"[^\"]*\"/database_id = \"$DB_ID\"/" wrangler.toml
+  sed -i '' "s/database_name = \"[^\"]*\"/database_name = \"$DB_NAME\"/" wrangler.toml
+else
+  # Linux sed
+  sed -i "s/database_id = \"[^\"]*\"/database_id = \"$DB_ID\"/" wrangler.toml
+  sed -i "s/database_name = \"[^\"]*\"/database_name = \"$DB_NAME\"/" wrangler.toml
+fi
+
+echo "Updated wrangler.toml:"
+grep -A2 "d1_databases" wrangler.toml
+
+# Run migrations
+echo ""
+echo "Running migrations..."
+npx wrangler d1 migrations apply "$DB_NAME" --remote
+
+echo ""
+echo "=========================================="
+echo "Database setup complete!"
+echo "Database name: $DB_NAME"
+echo "Database ID: $DB_ID"
+echo "=========================================="
+echo ""
+echo "You can now run: npm run dev"

--- a/my-sonicjs-app/wrangler.toml
+++ b/my-sonicjs-app/wrangler.toml
@@ -7,6 +7,10 @@ compatibility_flags = ["nodejs_compat"]
 workers_dev = true
 
 # D1 Database
+# Note: database_name and database_id are automatically updated by:
+# - GitHub Actions (for PR preview deployments)
+# - npm run setup:db (for local worktree development)
+# Run `npm run setup:db` to create a fresh database for your branch
 [[d1_databases]]
 binding = "DB"
 database_name = "my-sonicjs-app-db"


### PR DESCRIPTION
## Summary
- Adds automatic D1 database creation for each PR preview deployment
- Adds `npm run setup:db` script for local worktree development
- Each environment gets an isolated database for clean testing

## Changes
- **GitHub Actions**: Creates `sonicjs-pr-<branch>` database before deploying preview
- **setup-worktree-db.sh**: Creates `sonicjs-worktree-<branch>` database locally
- **package.json**: Added `setup:db` npm script
- **wrangler.toml**: Added documentation comments
- **CLAUDE_WORKFLOW.md**: Updated workflow documentation

## How It Works

### For PRs (Automatic)
GitHub Actions will:
1. Create/reuse a D1 database named after the branch
2. Apply all migrations
3. Update wrangler.toml with the new database ID
4. Deploy the preview

### For Local Development
```bash
cd my-sonicjs-app
npm run setup:db
```

## Test plan
- [ ] Create a test PR and verify the database is created in Cloudflare dashboard
- [ ] Verify migrations are applied to the new database
- [ ] Run E2E tests to confirm they work against the fresh database
- [ ] Test `npm run setup:db` locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)