### PR TITLE
fix: admin seed script - multiple issues causing login failure

### DIFF
--- a/my-sonicjs-app/scripts/seed-admin.ts
+++ b/my-sonicjs-app/scripts/seed-admin.ts
@@ -1,6 +1,7 @@
 import { createDb, users } from '@sonicjs-cms/core'
 import { eq } from 'drizzle-orm'
 import bcrypt from 'bcryptjs'
+import { getPlatformProxy } from 'wrangler'
 
 /**
  * Seed script to create initial admin user
@@ -14,17 +15,11 @@ import bcrypt from 'bcryptjs'
  * Password: [as entered during setup]
  */
 
-interface Env {
-  DB: D1Database
-}
-
 async function seed() {
-  // Get D1 database from Cloudflare environment
-  // @ts-ignore - getPlatformProxy is available in wrangler
-  const { env } = await import('@cloudflare/workers-types/experimental')
-  const platform = (env as any).getPlatformProxy?.() || { env: {} }
+  // Get D1 database from Cloudflare environment using wrangler's getPlatformProxy
+  const { env, dispose } = await getPlatformProxy()
 
-  if (!platform.env?.DB) {
+  if (!env?.DB) {
     console.error('❌ Error: DB binding not found')
     console.error('')
     console.error('Make sure you have:')
@@ -35,7 +30,7 @@ async function seed() {
     process.exit(1)
   }
 
-  const db = createDb(platform.env.DB)
+  const db = createDb(env.DB)
 
   try {
     // Check if admin user already exists
@@ -49,6 +44,7 @@ async function seed() {
       console.log('✓ Admin user already exists')
       console.log(`  Email: admin@sonicjs.com`)
       console.log(`  Role: ${existingUser.role}`)
+      await dispose()
       return
     }
 
@@ -76,8 +72,12 @@ async function seed() {
     console.log('You can now login at: http://localhost:8787/auth/login')
   } catch (error) {
     console.error('❌ Error creating admin user:', error)
+    await dispose()
     process.exit(1)
   }
+
+  // Clean up the platform proxy
+  await dispose()
 }
 
 // Run seed

--- a/packages/core/src/plugins/core-plugins/seed-data-plugin/services/seed-data-service.ts
+++ b/packages/core/src/plugins/core-plugins/seed-data-plugin/services/seed-data-service.ts
@@ -259,9 +259,9 @@ export class SeedDataService {
     const deleteContentStmt = this.db.prepare('DELETE FROM content')
     await deleteContentStmt.run()
 
-    // Delete users (but keep the admin user if it exists)
+    // Delete users (but keep admin users)
     const deleteUsersStmt = this.db.prepare(
-      "DELETE FROM users WHERE email != 'admin@sonicjs.com'"
+      "DELETE FROM users WHERE role != 'admin'"
     )
     await deleteUsersStmt.run()
   }

--- a/packages/create-app/templates/starter/README.md
+++ b/packages/create-app/templates/starter/README.md
@@ -42,9 +42,7 @@ A modern headless CMS built with [SonicJS](https://sonicjs.com) on Cloudflare's 
 6. **Open your browser:**
    Navigate to `http://localhost:8787/admin` to access the admin interface.
 
-   Default credentials:
-   - Email: `admin@sonicjs.com`
-   - Password: `admin`
+   Use the admin credentials you provided during project setup.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary

Fixes the admin login issue after fresh install (#343). Multiple root causes were identified and fixed.

### Root Causes Found

1. **Hardcoded admin in migrations** - `001_initial_schema.sql` was inserting a hardcoded `admin@sonicjs.com` user before the seed script ran
2. **Wrong wrangler import** - Seed script imported from types package instead of runtime package  
3. **Schema field mismatches** - Used wrong column names (`password` vs `passwordHash`) and missing required fields
4. **Password hashing mismatch** - Seed script used bcrypt but auth system uses SHA-256

### Changes

**packages/core/migrations/001_initial_schema.sql**
- Removed hardcoded admin user insert
- Removed sample content (referenced deleted admin)

**packages/core/src/db/migrations-bundle.ts**
- Regenerated with updated SQL

**packages/create-app/src/cli.js**
- Fixed wrangler import: `import { getPlatformProxy } from 'wrangler'`
- Fixed schema fields: `passwordHash`, `id`, `firstName`, `lastName`
- Fixed password hashing: Use SHA-256 with salt (same as auth system)
- Added proper `dispose()` calls for cleanup

**packages/create-app/templates/starter/README.md**
- Removed hardcoded credentials, replaced with "Use the admin credentials you provided during project setup"

**packages/core/.../seed-data-service.ts**
- Changed `clearSeedData()` to use role-based filtering instead of hardcoded email

**scripts/sync-versions.js**
- Now also syncs root package.json version during releases

## Test Results

✅ Tested with fresh install at `/tmp/sonicjs-test-manual/test-app`:
- Migrations run without seeding hardcoded admin
- Seed script creates user with custom email (`test@example.com`)
- Password hash is SHA-256 format (64 hex chars)
- Login API returns JWT token successfully

```bash
curl -X POST http://localhost:59965/auth/login \
  -H "Content-Type: application/json" \
  -d '{"email":"test@example.com","password":"testpass123"}'

# Response: {"user":{...},"token":"eyJhbG..."}
```

## Test plan

- [x] Run test install with custom admin email
- [x] Verify seed script runs successfully with `npm run seed`
- [x] Verify login works with provided credentials
- [x] Verify existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)