### PR TITLE
feat: add Discord notification to release scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,9 +31,10 @@
     "publish:core": "npm run build:core && npm publish --workspace=@sonicjs-cms/core",
     "publish:create-app": "npm publish --workspace=create-sonicjs",
     "publish:all": "npm run publish:core && npm run publish:create-app",
-    "release:patch": "npm run version:patch && npm run publish:all",
-    "release:minor": "npm run version:minor && npm run publish:all",
-    "release:major": "npm run version:major && npm run publish:all",
+    "release:patch": "npm run version:patch && npm run publish:all && node scripts/notify-discord.js",
+    "release:minor": "npm run version:minor && npm run publish:all && node scripts/notify-discord.js",
+    "release:major": "npm run version:major && npm run publish:all && node scripts/notify-discord.js",
+    "notify:discord": "node scripts/notify-discord.js",
     "db:reset": "npm run setup:db --workspace=my-sonicjs-app"
   },
   "dependencies": {

--- a/scripts/notify-discord.js
+++ b/scripts/notify-discord.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+
+/**
+ * Discord release notification script
+ *
+ * Posts a release notification to Discord when a new version is published.
+ * Requires DISCORD_WEBHOOK_URL environment variable to be set.
+ */
+
+import fs from 'fs'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const rootDir = path.join(__dirname, '..')
+const corePackageJsonPath = path.join(rootDir, 'packages/core/package.json')
+
+async function notifyDiscord() {
+  const webhookUrl = process.env.DISCORD_WEBHOOK_URL
+
+  if (!webhookUrl) {
+    console.warn('⚠ DISCORD_WEBHOOK_URL not set, skipping Discord notification')
+    return
+  }
+
+  try {
+    // Read core version
+    const corePackageJson = JSON.parse(fs.readFileSync(corePackageJsonPath, 'utf8'))
+    const version = corePackageJson.version
+
+    const message = {
+      embeds: [
+        {
+          title: `🚀 SonicJS v${version} Released!`,
+          description: `A new version of SonicJS has been published to npm.`,
+          color: 0x5865f2, // Discord blurple
+          fields: [
+            {
+              name: '📦 Install',
+              value: '```bash\nnpm create sonicjs@latest\n```',
+              inline: false,
+            },
+            {
+              name: '📚 Links',
+              value: [
+                '[npm](https://www.npmjs.com/package/@sonicjs-cms/core)',
+                '[GitHub](https://github.com/lane711/sonicjs)',
+                '[Docs](https://sonicjs.com)',
+              ].join(' • '),
+              inline: false,
+            },
+          ],
+          timestamp: new Date().toISOString(),
+          footer: {
+            text: 'SonicJS CMS',
+          },
+        },
+      ],
+    }
+
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(message),
+    })
+
+    if (response.ok) {
+      console.log(`✅ Discord notification sent for v${version}`)
+    } else {
+      const errorText = await response.text()
+      console.error(`❌ Discord notification failed: ${response.status} ${errorText}`)
+      process.exit(1)
+    }
+  } catch (error) {
+    console.error('❌ Error sending Discord notification:', error)
+    process.exit(1)
+  }
+}
+
+notifyDiscord()


### PR DESCRIPTION
## Summary
- Add Discord webhook notification that posts when a new version is released
- Notification includes version number, install command, and links to npm/GitHub/docs
- Requires `DISCORD_WEBHOOK_URL` environment variable to be set
- Added standalone `notify:discord` script for testing

## Test plan
- [ ] Set `DISCORD_WEBHOOK_URL` environment variable
- [ ] Run `npm run notify:discord` to test the notification
- [ ] Verify Discord message appears with correct formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)