### PR TITLE
fix: show warning instead of validation error on WIP settings tabs

### DIFF
--- a/packages/core/src/templates/pages/admin-settings.template.ts
+++ b/packages/core/src/templates/pages/admin-settings.template.ts
@@ -153,6 +153,15 @@ export function renderSettingsPage(data: SettingsPageData): string {
       const currentTab = '${activeTab}';
 
       async function saveAllSettings() {
+        // Tabs with implemented save functionality
+        const saveableTabs = ['general'];
+
+        // Check if current tab supports saving
+        if (!saveableTabs.includes(currentTab)) {
+          showNotification('Saving is not yet available for this settings section. This feature is under development.', 'warning');
+          return;
+        }
+
         // Collect all form data
         const formData = new FormData();
 


### PR DESCRIPTION
## Summary
- Fixes the "Save All Changes" button showing confusing "Site name and description are required" error on non-General settings tabs
- Now shows a warning notification explaining that saving is not yet available for WIP tabs (Appearance, Security, Notifications, Storage)
- General tab continues to work as expected

## Root Cause
The `saveAllSettings()` function was always routing to `/admin/settings/general` regardless of the active tab. When on non-General tabs, the form didn't contain `siteName` or `siteDescription` fields, causing backend validation to fail.

## Changes
Added a check in `saveAllSettings()` that:
1. Maintains a list of tabs with implemented save functionality
2. Shows a helpful warning notification for WIP tabs instead of attempting to save
3. Only proceeds with save when on a tab with working save endpoint

## Test plan
- [ ] Navigate to Admin > Settings > General tab, make changes, click "Save All Changes" - should save successfully
- [ ] Navigate to Admin > Settings > Appearance tab, click "Save All Changes" - should show warning notification
- [ ] Repeat for Security, Notifications, and Storage tabs - all should show warning
- [ ] Migrations and Database Tools tabs have their own action buttons, so "Save All Changes" should show warning there too

Fixes #345

🤖 Generated with [Claude Code](https://claude.com/claude-code)