### PR TITLE
fix: resolve invalid URL links in documentation and dashboard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,68 @@
+# Contributing to SonicJS
+
+Thank you for your interest in contributing to SonicJS!
+
+## Quick Links
+
+- **[Full Contributing Guide](https://sonicjs.com/contributing)** - Detailed guide on how to contribute
+- **[Good First Issues](https://github.com/lane711/sonicjs/labels/good%20first%20issue)** - Great starting points for new contributors
+- **[Help Wanted](https://github.com/lane711/sonicjs/labels/help%20wanted)** - Issues where we need community help
+
+## Getting Started
+
+1. **Fork the repository** on GitHub
+2. **Clone your fork:**
+   ```bash
+   git clone https://github.com/YOUR_USERNAME/sonicjs.git
+   cd sonicjs
+   ```
+3. **Install dependencies:**
+   ```bash
+   npm install
+   ```
+4. **Start development:**
+   ```bash
+   npm run dev
+   ```
+
+## Before You Start
+
+We appreciate every developer who wants to contribute. To ensure the best experience for both contributors and maintainers:
+
+- **Start with code, not meetings** - Submit at least one meaningful pull request before requesting deeper involvement
+- **Find an issue** - Check our [issue tracker](https://github.com/lane711/sonicjs/issues) for something to work on
+- **Claim the issue** - Comment on the issue to indicate you're working on it
+
+## What Counts as a Meaningful Contribution?
+
+- 🐛 **Bug Fixes** - Fix a bug with a well-tested solution
+- ✨ **New Features** - Implement a feature that has been discussed and approved
+- 📝 **Documentation** - Significantly improve or add documentation
+- 🧪 **Test Coverage** - Add meaningful tests for untested functionality
+
+## Code Standards
+
+- **TypeScript**: All code must be in TypeScript with proper types
+- **Testing**: New features must include tests
+- **Documentation**: Public APIs must be documented
+- **Formatting**: Use Prettier (runs automatically on commit)
+- **Linting**: ESLint rules must pass
+
+## Pull Request Checklist
+
+Before submitting a PR:
+
+- [ ] All tests pass (`npm test`)
+- [ ] Code is formatted (`npm run format`)
+- [ ] Linting passes (`npm run lint`)
+- [ ] Changes are documented if needed
+- [ ] PR description explains the changes
+- [ ] Related issue is referenced
+
+## Questions?
+
+- Check [existing issues](https://github.com/lane711/sonicjs/issues) - your question may already be answered
+- Ask in [GitHub Discussions](https://github.com/lane711/sonicjs/discussions) - for general questions
+- Join our [Discord](https://discord.gg/8bMy6bv3sZ) - for real-time chat
+
+We look forward to your contributions!

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -428,11 +428,11 @@ npm run dev
 
 ## 📖 Documentation
 
-- [Getting Started](https://docs.sonicjs.com/getting-started)
-- [API Reference](https://docs.sonicjs.com/api)
-- [Collections Guide](https://docs.sonicjs.com/collections)
-- [Plugin Development](https://docs.sonicjs.com/plugins)
-- [Deployment](https://docs.sonicjs.com/deployment)
+- [Getting Started](https://sonicjs.com/installation)
+- [API Reference](https://sonicjs.com/api)
+- [Collections Guide](https://sonicjs.com/collections)
+- [Plugin Development](https://sonicjs.com/plugins)
+- [Deployment](https://sonicjs.com/deployment)
 
 ## 🤝 Contributing
 
@@ -444,9 +444,9 @@ MIT © SonicJS Team - See [LICENSE](./LICENSE) for details.
 
 ## 💬 Support & Community
 
-- **Issues**: [GitHub Issues](https://github.com/sonicjs/sonicjs/issues)
-- **Discord**: [Join our community](https://discord.gg/sonicjs)
-- **Docs**: [docs.sonicjs.com](https://docs.sonicjs.com)
+- **Issues**: [GitHub Issues](https://github.com/lane711/sonicjs/issues)
+- **Discord**: [Join our community](https://discord.gg/8bMy6bv3sZ)
+- **Docs**: [sonicjs.com](https://sonicjs.com)
 - **Twitter**: [@sonicjscms](https://twitter.com/sonicjscms)
 
 ## 🔖 Resources

--- a/packages/core/src/templates/pages/admin-dashboard.template.ts
+++ b/packages/core/src/templates/pages/admin-dashboard.template.ts
@@ -55,7 +55,7 @@ export function renderDashboardPage(data: DashboardPageData): string {
         <p class="mt-2 text-sm/6 text-zinc-500 dark:text-zinc-400">Welcome to your SonicJS AI admin dashboard</p>
       </div>
       <div class="mt-4 sm:mt-0 flex items-center gap-x-3">
-        <a href="/docs/getting-started" target="_blank" class="inline-flex items-center justify-center gap-x-1.5 rounded-lg bg-lime-600 dark:bg-lime-700 px-3.5 py-2.5 text-sm font-semibold text-white hover:bg-lime-700 dark:hover:bg-lime-600 transition-colors shadow-sm">
+        <a href="https://sonicjs.com/installation" target="_blank" class="inline-flex items-center justify-center gap-x-1.5 rounded-lg bg-lime-600 dark:bg-lime-700 px-3.5 py-2.5 text-sm font-semibold text-white hover:bg-lime-700 dark:hover:bg-lime-600 transition-colors shadow-sm">
           <svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
             <path stroke-linecap="round" stroke-linejoin="round" d="M4.26 10.147a60.436 60.436 0 00-.491 6.347A48.627 48.627 0 0112 20.904a48.627 48.627 0 018.232-4.41 60.46 60.46 0 00-.491-6.347m-15.482 0a50.57 50.57 0 00-2.658-.813A59.905 59.905 0 0112 3.493a59.902 59.902 0 0110.399 5.84c-.896.248-1.783.52-2.658.814m-15.482 0A50.697 50.697 0 0112 13.489a50.702 50.702 0 017.74-3.342M6.75 15a.75.75 0 100-1.5.75.75 0 000 1.5zm0 0v-3.675A55.378 55.378 0 0112 8.443m-7.007 11.55A5.981 5.981 0 006.75 15.75v-1.5"/>
           </svg>

--- a/packages/create-app/README.md
+++ b/packages/create-app/README.md
@@ -269,7 +269,7 @@ npx create-sonicjs my-app
 ## Related
 
 - [@sonicjs-cms/core](../core) - Core framework
-- [SonicJS Documentation](https://docs.sonicjs.com)
+- [SonicJS Documentation](https://sonicjs.com)
 - [Cloudflare Workers](https://workers.cloudflare.com)
 
 ## Contributing
@@ -282,9 +282,9 @@ MIT © SonicJS Team
 
 ## Support
 
-- **Issues**: [GitHub Issues](https://github.com/sonicjs/sonicjs/issues)
-- **Discord**: [Join our community](https://discord.gg/sonicjs)
-- **Docs**: [docs.sonicjs.com](https://docs.sonicjs.com)
+- **Issues**: [GitHub Issues](https://github.com/lane711/sonicjs/issues)
+- **Discord**: [Join our community](https://discord.gg/8bMy6bv3sZ)
+- **Docs**: [sonicjs.com](https://sonicjs.com)
 
 ---
 

--- a/packages/create-app/src/cli.js
+++ b/packages/create-app/src/cli.js
@@ -825,7 +825,7 @@ function printSuccessMessage(answers) {
   console.log(kleur.cyan('  http://localhost:8787/admin'))
 
   console.log()
-  console.log(kleur.dim('Need help? Visit https://docs.sonicjs.com'))
+  console.log(kleur.dim('Need help? Visit https://sonicjs.com'))
   console.log()
 }
 

--- a/packages/create-app/templates/starter/README.md
+++ b/packages/create-app/templates/starter/README.md
@@ -114,16 +114,16 @@ Your collections are automatically available via REST API:
 
 ## Documentation
 
-- [SonicJS Documentation](https://docs.sonicjs.com)
-- [Collection Configuration](https://docs.sonicjs.com/collections)
-- [Plugin Development](https://docs.sonicjs.com/plugins)
-- [API Reference](https://docs.sonicjs.com/api)
+- [SonicJS Documentation](https://sonicjs.com)
+- [Collection Configuration](https://sonicjs.com/collections)
+- [Plugin Development](https://sonicjs.com/plugins)
+- [API Reference](https://sonicjs.com/api)
 
 ## Support
 
-- [GitHub Issues](https://github.com/sonicjs/sonicjs/issues)
-- [Discord Community](https://discord.gg/sonicjs)
-- [Documentation](https://docs.sonicjs.com)
+- [GitHub Issues](https://github.com/lane711/sonicjs/issues)
+- [Discord Community](https://discord.gg/8bMy6bv3sZ)
+- [Documentation](https://sonicjs.com)
 
 ## License
 

--- a/www/src/app/faq/page.mdx
+++ b/www/src/app/faq/page.mdx
@@ -639,13 +639,13 @@ Contact us at support@sonicjs.com for pricing.
 Multiple support channels available:
 
 **Documentation:**
-- [Documentation Site](https://docs.sonicjs.com)
+- [Documentation Site](https://sonicjs.com)
 - [API Reference](/api)
 - [Plugin Development Guide](/plugins/development)
 
 **Community:**
 - [GitHub Discussions](https://github.com/lane711/sonicjs/discussions)
-- [Discord Server](https://discord.gg/sonicjs)
+- [Discord Server](https://discord.gg/8bMy6bv3sZ)
 - [Twitter/X](https://twitter.com/sonicjs)
 
 **Professional Support:**

--- a/www/src/app/installation/page.mdx
+++ b/www/src/app/installation/page.mdx
@@ -449,8 +449,8 @@ wrangler r2 bucket info sonicjs-media-dev
 
 **Resources:**
 
-- 📚 [Full Documentation](https://docs.sonicjs.com)
-- 🐛 [GitHub Issues](https://github.com/lane711/sonicjs-ai/issues)
+- 📚 [Full Documentation](https://sonicjs.com)
+- 🐛 [GitHub Issues](https://github.com/lane711/sonicjs/issues)
 - 💬 [Discussions](https://github.com/lane711/sonicjs-ai/discussions)
 - 📖 [API Reference](/api)
 - 🏗️ [Architecture Guide](/architecture)

--- a/www/src/app/roadmap/page.mdx
+++ b/www/src/app/roadmap/page.mdx
@@ -437,7 +437,7 @@ Want to help shape the future of SonicJS? We welcome contributions!
 
 1. **Report Issues** - Found a bug? [Open an issue](https://github.com/lane711/sonicjs/issues)
 2. **Suggest Features** - Have an idea? Start a [discussion](https://github.com/lane711/sonicjs/discussions)
-3. **Submit PRs** - Ready to code? Check our [contributing guide](https://github.com/lane711/sonicjs/blob/main/CONTRIBUTING.md)
+3. **Submit PRs** - Ready to code? Check our [contributing guide](/contributing)
 4. **Write Docs** - Help improve our documentation
 5. **Spread the Word** - Star us on GitHub and share with others!
 


### PR DESCRIPTION
## Summary

- Added `CONTRIBUTING.md` file to repository root that redirects to the web documentation
- Fixed Dashboard "Developer Docs" button that was pointing to non-existent `/docs/getting-started` route
- Updated roadmap contributing guide link to use internal `/contributing` route instead of non-existent GitHub file
- Replaced all `docs.sonicjs.com` references with `sonicjs.com` (the actual live website)
- Fixed incorrect GitHub repo URLs (changed `sonicjs/sonicjs` to `lane711/sonicjs`)
- Updated Discord invite links to the correct invite code

## Test plan

- [ ] Verify CONTRIBUTING.md exists and links work
- [ ] Test Developer Docs button in admin dashboard points to valid URL
- [ ] Check roadmap page contributing link works
- [ ] Verify documentation links in README files are valid

Fixes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)