### PR TITLE
ci: auto-deploy www site on merge to main

### DIFF
--- a/.github/workflows/deploy-www.yml
+++ b/.github/workflows/deploy-www.yml
@@ -1,0 +1,34 @@
+name: Deploy WWW
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'www/**'
+      - '.github/workflows/deploy-www.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Deploy WWW to Cloudflare
+        run: npm run deploy:www
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
- Adds GitHub Actions workflow to automatically deploy the www site when changes in `www/` are merged to main
- Includes `workflow_dispatch` trigger for manual deployments from the GitHub Actions UI
- Uses existing Cloudflare secrets (`CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID`)

## Test plan
- [ ] Merge this PR and verify the workflow runs successfully
- [ ] Test manual trigger via Actions > Deploy WWW > Run workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)