### PR TITLE
Fixed admin mobile user dropdown not displaying

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -68,5 +68,7 @@
     "**/node_modules/**": true,
     "**/dist/**": true,
     "**/.wrangler/**": true
-  }
+  },
+  "prettier.singleQuote": true,
+  "prettier.printWidth": 100
 }

--- a/packages/core/src/templates/layouts/admin-layout-catalyst.template.ts
+++ b/packages/core/src/templates/layouts/admin-layout-catalyst.template.ts
@@ -366,8 +366,10 @@ export function renderAdminLayoutCatalyst(
 
     // User dropdown toggle
     function toggleUserDropdown() {
-      const dropdown = document.getElementById('userDropdown');
-      dropdown.classList.toggle('hidden');
+      const dropDowns = document.querySelectorAll('.userDropdown');
+      dropDowns.forEach(dropdown => {
+        dropdown.classList.toggle('hidden');
+      });
     }
 
     // Close dropdown when clicking outside
@@ -550,7 +552,7 @@ function renderCatalystSidebar(
 
   return `
     <nav class="flex h-full min-h-0 flex-col bg-white shadow-sm ring-1 ring-zinc-950/5 dark:bg-zinc-900 dark:ring-white/10 ${
-      isMobile ? "rounded-lg p-2 m-2" : ""
+      isMobile ? "is-mobile rounded-lg p-2 m-2" : ""
     }">
       ${closeButton}
 
@@ -668,7 +670,7 @@ function renderCatalystSidebar(
             </button>
 
             <!-- User Dropdown -->
-            <div id="userDropdown" class="hidden absolute bottom-full mb-2 left-0 right-0 mx-2 rounded-xl bg-white shadow-lg ring-1 ring-zinc-950/10 dark:bg-zinc-800 dark:ring-white/10 z-50">
+            <div class="userDropdown hidden absolute bottom-full mb-2 left-0 right-0 mx-2 rounded-xl bg-white shadow-lg ring-1 ring-zinc-950/10 dark:bg-zinc-800 dark:ring-white/10 z-50">
               <div class="p-2">
                 <div class="px-3 py-2 border-b border-zinc-950/5 dark:border-white/5">
                   <p class="text-sm font-medium text-zinc-950 dark:text-white">${

--- a/tests/e2e/03-admin-dashboard.spec.ts
+++ b/tests/e2e/03-admin-dashboard.spec.ts
@@ -209,4 +209,59 @@ test.describe('Admin Dashboard', () => {
     // Should contain either activity list or empty state
     expect(containerContent).toMatch(/ul role="list"|No recent activity/);
   });
+
+  test('should open and close User Dropdown menu in desktop and mobile', async ({ page }) => {
+    // Test Desktop Version
+    await page.setViewportSize({ width: 1280, height: 720 });
+    await page.goto('/admin');
+
+    // Find the user menu button (desktop version)
+    const desktopUserButton = page.locator('[data-user-menu]').first();
+    await expect(desktopUserButton).toBeVisible({ timeout: 5000 });
+
+    // Verify dropdown is initially hidden
+    const desktopDropdown = page.locator('.userDropdown:not(.is-mobile)').first();
+    await expect(desktopDropdown).toBeHidden();
+
+    // Click to open dropdown
+    await desktopUserButton.click();
+    await expect(desktopDropdown).toBeVisible({ timeout: 2000 });
+
+    // Verify dropdown contains user information
+    await expect(desktopDropdown.locator('a[href="/admin/profile"]')).toBeVisible();
+
+    // Click to close dropdown
+    await desktopUserButton.click();
+    await expect(desktopDropdown).toBeHidden();
+
+    // Test Mobile Version
+    await page.setViewportSize({ width: 375, height: 667 });
+    await page.goto('/admin');
+
+    // Open mobile sidebar first (mobile nav is hidden by default)
+    const mobileMenuButton = page.locator('button[aria-label="Open navigation"]');
+    if (await mobileMenuButton.isVisible()) {
+      await mobileMenuButton.click();
+      await page.waitForTimeout(500); // Wait for sidebar animation
+    }
+
+    // Find the user menu button (mobile version)
+    const mobileUserButton = page.locator('[data-user-menu]').last();
+    await expect(mobileUserButton).toBeVisible({ timeout: 5000 });
+
+    // Verify dropdown is initially hidden
+    const mobileDropdown = page.locator('.is-mobile .userDropdown').last();
+    await expect(mobileDropdown).toBeHidden();
+
+    // Click to open dropdown
+    await mobileUserButton.click();
+    await expect(mobileDropdown).toBeVisible({ timeout: 2000 });
+
+    // Verify dropdown contains user information
+    await expect(mobileDropdown.locator('a[href="/admin/profile"]')).toBeVisible();
+
+    // Click to close dropdown
+    await mobileUserButton.click();
+    await expect(mobileDropdown).toBeHidden();
+  });
 }); 


### PR DESCRIPTION
## Description
The user dropdown menu in the admin dashboard would not open because it shared the same id with the desktop version of the dropdown.  This was resolved by using class="userDropdown" instead.

Fixes # 398

## Changes
- Modified the admin layout template to use class-based dropdowns instead of an ID.
- Added end-to-end tests for opening and closing the user dropdown menu in both desktop and mobile views.
- Updated VSCode settings to enforce single quotes and a print width of 100 for better code formatting.

## Testing
1. Log into the admin dashboard
2. Shrink the viewport width so the sidebar disappears
3. Open the mobile sidebar
4. Click on the button to open the user dropdown
5. Verify user dropdown appears

### Unit Tests
- [ ] Added/updated unit tests
- [ ] All unit tests passing
^^ n/a as templates don't have unit tests.

### E2E Tests
- [x] Added/updated E2E tests
- [x] All E2E tests passing

## Screenshots/Videos
n/a

## Checklist
- [x] Code follows project conventions
- [x] Tests added/updated and passing
- [x] Type checking passes
- [x] No console errors or warnings
- [ n/a ] Documentation updated (if needed)

---
Generated with Claude Code in Conductor
