### PR TITLE
fix: search in content list now includes data field

### DIFF
--- a/packages/core/src/routes/admin-content.ts
+++ b/packages/core/src/routes/admin-content.ts
@@ -137,8 +137,8 @@ adminContentRoutes.get('/', async (c) => {
     }
 
     if (search) {
-      conditions.push('(c.title LIKE ? OR c.slug LIKE ?)')
-      params.push(`%${search}%`, `%${search}%`)
+      conditions.push('(c.title LIKE ? OR c.slug LIKE ? OR c.data LIKE ?)')
+      params.push(`%${search}%`, `%${search}%`, `%${search}%`)
     }
 
     if (modelName !== 'all') {


### PR DESCRIPTION
## Summary

- Extended the content list search query to also search within the JSON `data` column
- Users can now find content by body text and custom field values, not just title and slug

## Changes

Updated `packages/core/src/routes/admin-content.ts` to include the `data` field in the search WHERE clause:

```typescript
// Before
conditions.push('(c.title LIKE ? OR c.slug LIKE ?)')

// After  
conditions.push('(c.title LIKE ? OR c.slug LIKE ? OR c.data LIKE ?)')
```

## Test plan

- [x] All unit tests pass (360 passed)
- [ ] Manual testing: search for content by body text in admin content list
- [ ] Verify search still works for title and slug

Fixes #400

🤖 Generated with [Claude Code](https://claude.com/claude-code)