### PR TITLE
docs: update www version badge to 2.3.12

### DIFF
--- a/www/src/components/Layout.tsx
+++ b/www/src/components/Layout.tsx
@@ -11,7 +11,7 @@ import { Navigation } from '@/components/Navigation'
 import { SectionProvider, type Section } from '@/components/SectionProvider'
 
 // Version from core package
-const version = '2.3.8'
+const version = '2.3.12'
 
 export function Layout({
   children,


### PR DESCRIPTION
## Summary
- Update the documentation site version badge from 2.3.8 to 2.3.12
- The changelog content for v2.3.12 was already present on home page and changelog page

## Test plan
- [ ] Verify version badge shows "v2.3.12" in the sidebar
- [ ] Confirm changelog section on home page displays v2.3.12 as latest

🤖 Generated with [Claude Code](https://claude.com/claude-code)