### PR TITLE
feat(www): make version references dynamic across doc site

### DIFF
--- a/scripts/sync-versions.js
+++ b/scripts/sync-versions.js
@@ -8,6 +8,7 @@
  * 2. Updates the version in packages/create-app/src/cli.js
  * 3. Syncs the create-sonicjs package version to match core version
  * 4. Syncs the root package.json version to match core version
+ * 5. Syncs the www documentation site version
  */
 
 import fs from 'fs'
@@ -22,6 +23,7 @@ const rootPackageJsonPath = path.join(rootDir, 'package.json')
 const corePackageJsonPath = path.join(rootDir, 'packages/core/package.json')
 const createAppCliPath = path.join(rootDir, 'packages/create-app/src/cli.js')
 const createAppPackageJsonPath = path.join(rootDir, 'packages/create-app/package.json')
+const wwwVersionPath = path.join(rootDir, 'www/src/lib/version.ts')
 
 async function syncVersions() {
   try {
@@ -61,6 +63,23 @@ async function syncVersions() {
     fs.writeFileSync(rootPackageJsonPath, JSON.stringify(rootPackageJson, null, 2) + '\n', 'utf8')
 
     console.log(`✓ Synced root package.json from ${oldRootVersion} to ${coreVersion}`)
+
+    // Sync www documentation site version
+    if (fs.existsSync(wwwVersionPath)) {
+      let wwwVersionContent = fs.readFileSync(wwwVersionPath, 'utf8')
+      const wwwVersionRegex = /export const VERSION = '[^']+'/
+      const newWwwVersionString = `export const VERSION = '${coreVersion}'`
+
+      if (wwwVersionRegex.test(wwwVersionContent)) {
+        wwwVersionContent = wwwVersionContent.replace(wwwVersionRegex, newWwwVersionString)
+        fs.writeFileSync(wwwVersionPath, wwwVersionContent, 'utf8')
+        console.log(`✓ Synced www documentation version to ${coreVersion}`)
+      } else {
+        console.warn('⚠ Could not find VERSION export in www/src/lib/version.ts')
+      }
+    } else {
+      console.warn('⚠ www/src/lib/version.ts not found, skipping www version sync')
+    }
 
     console.log('\n✅ Version sync complete!')
     console.log('\nNext steps:')

--- a/www/src/app/page.mdx
+++ b/www/src/app/page.mdx
@@ -252,19 +252,12 @@ Join thousands of developers building the future of web APIs
   </div>
 
   <div className="space-y-6">
-    <div className="border-l-4 border-emerald-500 dark:border-emerald-400 pl-4 py-1">
-      <div className="flex items-center gap-2 mb-2">
-        <span className="text-xs font-bold px-2 py-1 rounded bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300">v2.3.12</span>
-        <span className="text-xs px-2 py-1 rounded bg-gradient-to-r from-orange-100 to-red-100 dark:from-orange-900/30 dark:to-red-900/30 border border-orange-300 dark:border-orange-700 text-orange-800 dark:text-orange-300 font-bold">LATEST</span>
-        <span className="text-sm text-gray-500 dark:text-gray-400">2025-12-10</span>
+    <LatestVersionEntry date="2025-12-10">
+      <div className="flex items-start gap-2">
+        <span className="text-emerald-600 dark:text-emerald-400 mt-0.5">✓</span>
+        <span className="text-gray-700 dark:text-gray-300">Various improvements and bug fixes</span>
       </div>
-      <div className="text-sm space-y-1">
-        <div className="flex items-start gap-2">
-          <span className="text-emerald-600 dark:text-emerald-400 mt-0.5">✓</span>
-          <span className="text-gray-700 dark:text-gray-300">Various improvements and bug fixes</span>
-        </div>
-      </div>
-    </div>
+    </LatestVersionEntry>
 
     <div className="border-l-4 border-blue-500 dark:border-blue-400 pl-4 py-1">
       <div className="flex items-center gap-2 mb-2">

--- a/www/src/app/quickstart/page.mdx
+++ b/www/src/app/quickstart/page.mdx
@@ -70,7 +70,7 @@ Access the admin dashboard at [http://localhost:8787/admin](http://localhost:878
 
 ### Access the Admin Dashboard
 
-Navigate to **http://localhost:8787/admin** and log in with the default credentials.
+Navigate to **http://localhost:8787/admin** and log in with the credentials you entered during setup.
 
 The admin interface provides:
 

--- a/www/src/app/roadmap/page.mdx
+++ b/www/src/app/roadmap/page.mdx
@@ -444,11 +444,4 @@ Want to help shape the future of SonicJS? We welcome contributions!
 
 ---
 
-<div className="my-8 p-6 rounded-xl bg-gradient-to-r from-blue-50 to-purple-50 dark:from-blue-900/20 dark:to-purple-900/20 border border-blue-200 dark:border-blue-800 text-center">
-  <span className="block text-lg text-gray-700 dark:text-gray-300 mb-4">
-    SonicJS is actively maintained with <strong>3,683+ commits</strong> and <strong>7 years of development</strong>.
-  </span>
-  <span className="block text-sm text-gray-500 dark:text-gray-400">
-    Last updated: November 2025 | Version 2.3.2
-  </span>
-</div>
+<ActivelyMaintainedFooter />

--- a/www/src/components/Layout.tsx
+++ b/www/src/components/Layout.tsx
@@ -9,9 +9,7 @@ import { Header } from '@/components/Header'
 import { Logo } from '@/components/Logo'
 import { Navigation } from '@/components/Navigation'
 import { SectionProvider, type Section } from '@/components/SectionProvider'
-
-// Version from core package
-const version = '2.3.12'
+import { VERSION } from '@/lib/version'
 
 export function Layout({
   children,
@@ -35,7 +33,7 @@ export function Layout({
                 <Logo className="h-6" />
               </Link>
               <span className="inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 ring-1 ring-inset ring-blue-700/10 dark:bg-blue-500/10 dark:text-blue-400 dark:ring-blue-500/20">
-                v{version}
+                v{VERSION}
               </span>
             </div>
             <Header />

--- a/www/src/components/VersionInfo.tsx
+++ b/www/src/components/VersionInfo.tsx
@@ -1,0 +1,66 @@
+'use client'
+
+import { VERSION, getLastUpdatedDate } from '@/lib/version'
+
+export function VersionBadge({
+  className = '',
+}: {
+  className?: string
+}) {
+  return (
+    <span
+      className={`text-xs font-bold px-2 py-1 rounded bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 ${className}`}
+    >
+      v{VERSION}
+    </span>
+  )
+}
+
+export function LatestVersionEntry({
+  date,
+  children,
+}: {
+  date: string
+  children: React.ReactNode
+}) {
+  return (
+    <div className="border-l-4 border-emerald-500 dark:border-emerald-400 pl-4 py-1">
+      <div className="flex items-center gap-2 mb-2">
+        <span className="text-xs font-bold px-2 py-1 rounded bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300">
+          v{VERSION}
+        </span>
+        <span className="text-xs px-2 py-1 rounded bg-gradient-to-r from-orange-100 to-red-100 dark:from-orange-900/30 dark:to-red-900/30 border border-orange-300 dark:border-orange-700 text-orange-800 dark:text-orange-300 font-bold">
+          LATEST
+        </span>
+        <span className="text-sm text-gray-500 dark:text-gray-400">{date}</span>
+      </div>
+      <div className="text-sm space-y-1">{children}</div>
+    </div>
+  )
+}
+
+export function VersionText() {
+  return <span>v{VERSION}</span>
+}
+
+export function LastUpdatedInfo() {
+  return (
+    <span className="block text-sm text-gray-500 dark:text-gray-400">
+      Last updated: {getLastUpdatedDate()} | Version {VERSION}
+    </span>
+  )
+}
+
+export function ActivelyMaintainedFooter() {
+  return (
+    <div className="my-8 p-6 rounded-xl bg-gradient-to-r from-blue-50 to-purple-50 dark:from-blue-900/20 dark:to-purple-900/20 border border-blue-200 dark:border-blue-800 text-center">
+      <span className="block text-lg text-gray-700 dark:text-gray-300 mb-4">
+        SonicJS is actively maintained with <strong>3,683+ commits</strong> and{' '}
+        <strong>7 years of development</strong>.
+      </span>
+      <LastUpdatedInfo />
+    </div>
+  )
+}
+
+export { VERSION }

--- a/www/src/components/mdx.tsx
+++ b/www/src/components/mdx.tsx
@@ -13,6 +13,14 @@ export { Tabs } from '@/components/Tabs'
 export { ApiEndpoint } from '@/components/ApiEndpoint'
 export { CodeExample } from '@/components/CodeExample'
 export { FeatureGrid } from '@/components/FeatureGrid'
+export {
+  VersionBadge,
+  VersionText,
+  LastUpdatedInfo,
+  ActivelyMaintainedFooter,
+  LatestVersionEntry,
+  VERSION,
+} from '@/components/VersionInfo'
 
 export function wrapper({ children }: { children: React.ReactNode }) {
   return (

--- a/www/src/lib/version.ts
+++ b/www/src/lib/version.ts
@@ -1,0 +1,28 @@
+// Version configuration for the SonicJS documentation site
+// This file provides a single source of truth for version information
+//
+// NOTE: This version is automatically kept in sync with packages/core/package.json
+// When releasing a new version, run `npm run version:patch` (or minor/major) from the root
+// which will update this file via scripts/sync-versions.js
+
+export const VERSION = '2.3.12'
+
+// Helper function to get the current month/year for "Last updated"
+export function getLastUpdatedDate(): string {
+  const now = new Date()
+  const months = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ]
+  return `${months[now.getMonth()]} ${now.getFullYear()}`
+}


### PR DESCRIPTION
## Summary

- Create centralized version config (`www/src/lib/version.ts`) that exports `VERSION` constant
- Add `VersionInfo` React components for displaying version info in MDX pages (`VersionBadge`, `VersionText`, `LastUpdatedInfo`, `ActivelyMaintainedFooter`, `LatestVersionEntry`)
- Update Layout.tsx badge near logo to use dynamic VERSION
- Update roadmap page footer to use `<ActivelyMaintainedFooter />` component (includes "Last updated: Month Year | Version X.X.X")
- Update home page latest changelog entry to use `<LatestVersionEntry />` component
- Update `scripts/sync-versions.js` to automatically sync the www version when running `npm run version:patch/minor/major`
- Fix quickstart page to reference "credentials you entered during setup" instead of "default credentials"

## Test plan

- [ ] Run `npm run build:www` to verify the site builds successfully
- [ ] Visit the doc site and verify version badge appears near logo
- [ ] Visit /roadmap and verify the footer shows current version and date dynamically
- [ ] Visit homepage and verify the latest changelog entry shows current version
- [ ] Run `node scripts/sync-versions.js` (dry run) to verify it would update www version

🤖 Generated with [Claude Code](https://claude.com/claude-code)