### PR TITLE
feat(www): add Google Analytics tracking

### DIFF
--- a/www/src/app/layout.tsx
+++ b/www/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import { type Metadata } from 'next'
+import Script from 'next/script'
 
 import { Providers } from '@/app/providers'
 import { Layout } from '@/components/Layout'
@@ -25,6 +26,20 @@ export default function RootLayout({
 }) {
   return (
     <html lang="en" className="h-full" suppressHydrationWarning>
+      <head>
+        <Script
+          src="https://www.googletagmanager.com/gtag/js?id=G-FWS35H2E1W"
+          strategy="afterInteractive"
+        />
+        <Script id="google-analytics" strategy="afterInteractive">
+          {`
+            window.dataLayer = window.dataLayer || [];
+            function gtag(){dataLayer.push(arguments);}
+            gtag('js', new Date());
+            gtag('config', 'G-FWS35H2E1W');
+          `}
+        </Script>
+      </head>
       <body className="flex min-h-full bg-white antialiased dark:bg-zinc-900">
         <Providers>
           <div className="w-full">


### PR DESCRIPTION
## Summary
- Add Google Analytics (G-FWS35H2E1W) to the documentation site
- Uses Next.js Script component with `afterInteractive` strategy for optimal loading

## Test plan
- [ ] Verify site builds without errors
- [ ] Check that GA script loads on the deployed site
- [ ] Confirm pageviews appear in Google Analytics dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)