### PR TITLE
feat(www): add SEO improvements and content agent commands

### DIFF
--- a/.claude/commands/seo-audit.md
+++ b/.claude/commands/seo-audit.md
@@ -1,0 +1,69 @@
+# SEO Audit for SonicJS Website
+
+Perform a comprehensive SEO audit of the SonicJS documentation website (www/).
+
+## Audit Checklist
+
+### 1. Technical SEO
+- [ ] Check for sitemap.xml existence and validity
+- [ ] Check for robots.txt configuration
+- [ ] Verify meta tags on all pages (title, description)
+- [ ] Check for canonical URLs
+- [ ] Verify proper heading hierarchy (H1-H6)
+- [ ] Check for broken internal links
+- [ ] Verify mobile responsiveness
+- [ ] Check page load performance
+
+### 2. On-Page SEO
+- [ ] Review title tags (50-60 chars, include keywords)
+- [ ] Review meta descriptions (150-160 chars)
+- [ ] Check OpenGraph tags for social sharing
+- [ ] Verify image alt text
+- [ ] Check URL structure (clean, descriptive)
+- [ ] Review internal linking structure
+- [ ] Check for duplicate content issues
+
+### 3. Content SEO
+- [ ] Identify thin content pages
+- [ ] Find keyword opportunities
+- [ ] Check content freshness
+- [ ] Review heading optimization
+- [ ] Identify content gaps vs competitors
+
+### 4. Structured Data
+- [ ] Check for JSON-LD implementation
+- [ ] Verify Organization schema
+- [ ] Check for Article/BlogPosting schema
+- [ ] Verify Breadcrumb schema
+- [ ] Check SoftwareApplication schema for CMS
+
+## Files to Inspect
+
+```
+www/
+├── src/app/layout.tsx          # Root layout with meta
+├── src/app/page.mdx            # Homepage
+├── src/app/*/page.mdx          # All doc pages
+├── public/robots.txt           # Robots file
+├── public/sitemap.xml          # Sitemap
+└── next.config.mjs             # Next.js config
+```
+
+## Output Format
+
+Create a report with:
+1. **Score**: Overall SEO health (0-100)
+2. **Critical Issues**: Must fix immediately
+3. **Warnings**: Should fix soon
+4. **Opportunities**: Nice to have improvements
+5. **Action Items**: Prioritized list of fixes
+
+## Recommended Fixes
+
+After audit, implement fixes in this order:
+1. Add/fix sitemap.xml
+2. Add/fix robots.txt
+3. Add missing meta tags
+4. Implement structured data
+5. Fix broken links
+6. Optimize images

--- a/.claude/commands/seo-blog.md
+++ b/.claude/commands/seo-blog.md
@@ -1,0 +1,50 @@
+# Generate SEO-Optimized Blog Post
+
+Generate a high-quality, SEO-optimized blog post for SonicJS on the topic: $ARGUMENTS
+
+## Instructions
+
+1. **Research Phase**:
+   - Search the web for current trends and competitor content on this topic
+   - Identify the primary keyword and 3-5 secondary keywords
+   - Find the search intent (informational, transactional, navigational)
+
+2. **Content Creation**:
+   - Write a comprehensive blog post (1500-2500 words)
+   - Use proper heading hierarchy (H1 > H2 > H3)
+   - Include code examples where relevant (use SonicJS syntax)
+   - Add internal links to SonicJS documentation
+   - Include a clear call-to-action
+
+3. **SEO Elements**:
+   - Meta title (50-60 characters)
+   - Meta description (150-160 characters)
+   - URL slug (lowercase, hyphenated)
+   - OpenGraph tags
+   - Target keyword density: 1-2%
+
+4. **Output Format**:
+   Create the blog post as an MDX file with frontmatter metadata.
+
+## File Location
+
+Create the file at: `www/src/app/blog/[generated-slug]/page.mdx`
+
+Or if blog directory doesn't exist, create: `www/src/content/blog/[generated-slug].mdx`
+
+## Content Guidelines
+
+- Write for developers (technical audience)
+- Be specific and actionable
+- Include working code examples
+- Reference official SonicJS features accurately
+- Compare fairly with competitors (when relevant)
+- End with next steps or call-to-action
+
+## Example Topics
+
+- "Building a REST API with SonicJS in 10 Minutes"
+- "SonicJS vs Strapi: Which Headless CMS Should You Choose?"
+- "How to Deploy SonicJS to Cloudflare Workers"
+- "Creating Custom Collections in SonicJS"
+- "SonicJS Authentication: A Complete Guide"

--- a/.claude/commands/seo-discord-sync.md
+++ b/.claude/commands/seo-discord-sync.md
@@ -1,0 +1,111 @@
+# Discord to Searchable Content Sync
+
+Help surface valuable Discord discussions as searchable web content for SEO benefits.
+
+## Purpose
+
+Discord conversations contain valuable community knowledge that:
+- Answers common questions
+- Shows real-world use cases
+- Demonstrates community engagement
+- Contains solutions to problems
+
+But Discord content isn't indexed by search engines. This command helps transform that content into searchable resources.
+
+## Legitimate Approaches
+
+### 1. FAQ Generation from Discord
+- Review Discord channels for frequently asked questions
+- Extract Q&A pairs with proper attribution
+- Create FAQ pages in the documentation
+- Link back to Discord for continued discussion
+
+**Output location**: `www/src/app/faq/page.mdx`
+
+### 2. Community Showcase
+- Highlight real projects built with SonicJS
+- Feature community members (with permission)
+- Share success stories and use cases
+
+**Output location**: `www/src/app/showcase/page.mdx`
+
+### 3. Troubleshooting Guide
+- Compile common issues and solutions from Discord
+- Create searchable troubleshooting documentation
+- Include error messages for SEO (people search exact errors)
+
+**Output location**: `www/src/app/troubleshooting/page.mdx`
+
+### 4. Discussion Archive (With Consent)
+- Archive helpful Discord threads (with permission)
+- Make them searchable and linkable
+- Maintain attribution to original authors
+
+## Implementation Options
+
+### Option A: Manual Curation
+1. Identify valuable Discord threads
+2. Summarize into documentation
+3. Add proper attribution
+4. Link to original Discord
+
+### Option B: Discord Bot Integration
+Create a bot that:
+1. Watches for resolved support threads
+2. Extracts Q&A with user consent
+3. Formats as MDX content
+4. Creates PR for review
+
+### Option C: Community Wiki
+1. Set up a wiki-style section in docs
+2. Allow community contributions
+3. Moderate for quality
+4. Cross-link with Discord
+
+## Content Template
+
+```mdx
+---
+title: "[Question from Discord]"
+description: "Community answer to: [question summary]"
+source: "Discord #help channel"
+contributors: ["@username1", "@username2"]
+date: "YYYY-MM-DD"
+---
+
+# [Question]
+
+**Asked by**: @username in #channel
+
+[Original question text]
+
+## Solution
+
+[Accepted answer or solution]
+
+## Discussion
+
+[Key points from the thread]
+
+## Related Resources
+
+- [Link to docs](/docs/relevant-page)
+- [Discord thread](discord-link) - Join the conversation
+```
+
+## Ethics & Guidelines
+
+- **Always get permission** before featuring someone's content
+- **Proper attribution** to original authors
+- **No fabrication** - only use real discussions
+- **Respect privacy** - don't expose personal information
+- **Link back** to Discord to drive community engagement
+- **Keep updated** - mark outdated content
+
+## Discord Channels to Monitor
+
+- #help / #support - Common questions
+- #showcase - Project examples
+- #general - Feature discussions
+- #bugs - Common issues and solutions
+- #feature-requests - Community needs

--- a/.claude/commands/seo-keywords.md
+++ b/.claude/commands/seo-keywords.md
@@ -1,0 +1,95 @@
+# Keyword Research for SonicJS
+
+Perform keyword research to identify ranking opportunities for SonicJS.
+
+## Research Process
+
+### 1. Competitor Analysis
+Search the web to analyze what keywords competitors rank for:
+- **Strapi** - Most popular open-source headless CMS
+- **Sanity** - Developer-focused CMS
+- **Contentful** - Enterprise headless CMS
+- **Payload CMS** - TypeScript headless CMS
+- **Directus** - Open-source data platform
+- **KeystoneJS** - Node.js headless CMS
+
+### 2. Keyword Categories
+
+#### Core Product Keywords
+- headless cms
+- open source cms
+- typescript cms
+- api-first cms
+
+#### Platform-Specific Keywords
+- cloudflare workers cms
+- cloudflare d1 cms
+- edge cms
+- serverless cms
+- hono framework cms
+
+#### Feature Keywords
+- cms with rest api
+- cms with admin panel
+- self-hosted headless cms
+- developer-friendly cms
+
+#### Long-tail Keywords
+- how to build headless cms
+- best cms for cloudflare
+- typescript content management
+- jamstack cms comparison
+
+#### Problem-Solution Keywords
+- wordpress alternative for developers
+- strapi alternative
+- contentful free alternative
+- cms without database server
+
+### 3. Search Intent Analysis
+
+For each keyword, identify:
+- **Informational**: Learning/researching (target with blog posts)
+- **Navigational**: Looking for specific site (ensure brand presence)
+- **Transactional**: Ready to use/buy (target with landing pages)
+- **Commercial**: Comparing options (target with comparison content)
+
+## Output Format
+
+Create a keyword research report with:
+
+```markdown
+## Keyword Research Report - SonicJS
+
+### High Priority Keywords (Monthly Search Volume)
+
+| Keyword | Volume | Difficulty | Intent | Current Rank | Target Content |
+|---------|--------|------------|--------|--------------|----------------|
+| headless cms | 10K+ | High | Commercial | N/A | Comparison page |
+| typescript cms | 1K | Medium | Commercial | N/A | Homepage |
+| cloudflare cms | 500 | Low | Informational | N/A | Tutorial |
+
+### Quick Win Opportunities
+[Keywords with low difficulty where SonicJS could rank quickly]
+
+### Content Gaps
+[Topics competitors cover that SonicJS doesn't]
+
+### Recommended Content Calendar
+[Prioritized list of content to create]
+```
+
+## Tools & Methods
+
+1. **Web Search**: Search for keywords and analyze SERP
+2. **Competitor Sites**: Review competitor documentation structure
+3. **Related Searches**: Use "People also ask" and related queries
+4. **Community Questions**: Common questions on Reddit, Stack Overflow, Discord
+
+## Action Items After Research
+
+1. Update homepage meta tags with primary keywords
+2. Create content targeting identified gaps
+3. Optimize existing pages for relevant keywords
+4. Build internal linking around keyword clusters
+5. Monitor rankings over time

--- a/.claude/commands/seo-sitemap.md
+++ b/.claude/commands/seo-sitemap.md
@@ -1,0 +1,78 @@
+# Generate/Update Sitemap for SonicJS
+
+Create or update the sitemap.xml for the SonicJS documentation website.
+
+## Instructions
+
+1. **Discover all pages** in the www/ Next.js app:
+   - Scan `www/src/app/` for all `page.mdx` and `page.tsx` files
+   - Include the homepage
+   - Include all documentation pages
+   - Include blog posts (if any)
+
+2. **Generate sitemap.xml** with:
+   - Full URLs (https://sonicjs.com/...)
+   - Last modified dates (from git or file mtime)
+   - Change frequency estimates
+   - Priority values (1.0 for homepage, 0.8 for main docs, 0.6 for sub-pages)
+
+3. **Create sitemap route** for Next.js:
+   - Create `www/src/app/sitemap.ts` for dynamic sitemap generation
+   - Or create static `www/public/sitemap.xml`
+
+## Sitemap Format
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://sonicjs.com/</loc>
+    <lastmod>2024-01-15</lastmod>
+    <changefreq>weekly</changefreq>
+    <priority>1.0</priority>
+  </url>
+  <!-- More URLs -->
+</urlset>
+```
+
+## Next.js Dynamic Sitemap (Preferred)
+
+```typescript
+// www/src/app/sitemap.ts
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = 'https://sonicjs.com'
+
+  // Get all doc pages dynamically
+  const docs = [
+    { url: '/', priority: 1.0 },
+    { url: '/getting-started', priority: 0.9 },
+    // ... discover all pages
+  ]
+
+  return docs.map(doc => ({
+    url: `${baseUrl}${doc.url}`,
+    lastModified: new Date(),
+    changeFrequency: 'weekly',
+    priority: doc.priority,
+  }))
+}
+```
+
+## Also Create robots.txt
+
+```
+# www/public/robots.txt
+User-agent: *
+Allow: /
+
+Sitemap: https://sonicjs.com/sitemap.xml
+```
+
+## Verification
+
+After creating:
+1. Visit /sitemap.xml to verify it loads
+2. Test with Google Search Console
+3. Submit sitemap to search engines

--- a/.claude/commands/seo.md
+++ b/.claude/commands/seo.md
@@ -1,0 +1,164 @@
+# SonicJS SEO Expert Agent
+
+You are an SEO expert agent for SonicJS, a modern headless CMS built for Cloudflare's edge platform. Your goal is to help SonicJS rank for relevant keywords and grow organic traffic through legitimate, high-quality content strategies.
+
+## Your Capabilities
+
+### 1. Keyword Research & Strategy
+- Identify relevant keywords for headless CMS, Cloudflare Workers, edge computing, and TypeScript CMS space
+- Analyze competitor positioning (Strapi, Sanity, Contentful, Payload CMS, Directus)
+- Find long-tail opportunities and content gaps
+- Track keyword difficulty and search volume estimates
+
+### 2. Blog Content Generation
+When creating blog posts, follow this structure:
+
+**File Location**: Create in `www/src/app/blog/[slug]/page.mdx` format or as standalone MDX files
+
+**Blog Post Template**:
+```mdx
+export const metadata = {
+  title: '[POST_TITLE] | SonicJS Blog',
+  description: '[META_DESCRIPTION - 150-160 chars]',
+  keywords: ['keyword1', 'keyword2', 'keyword3'],
+  author: 'SonicJS Team',
+  publishedAt: '[YYYY-MM-DD]',
+  openGraph: {
+    title: '[POST_TITLE]',
+    description: '[META_DESCRIPTION]',
+    type: 'article',
+    publishedTime: '[YYYY-MM-DD]',
+  }
+}
+
+# [H1 TITLE - Include Primary Keyword]
+
+[Opening paragraph - hook the reader, state the problem/opportunity]
+
+## [H2 Section - Include Secondary Keyword]
+
+[Content with practical examples, code snippets where relevant]
+
+## Key Takeaways
+
+- Bullet point 1
+- Bullet point 2
+- Bullet point 3
+
+## Conclusion
+
+[Call to action - try SonicJS, read docs, join Discord]
+```
+
+**Content Types to Create**:
+1. **Tutorials**: Step-by-step guides (e.g., "How to Build a Blog with SonicJS and Cloudflare Workers")
+2. **Comparisons**: vs competitors (e.g., "SonicJS vs Strapi: Edge-First CMS Comparison")
+3. **Technical Deep Dives**: Architecture explanations (e.g., "Why Edge Computing Makes Your CMS 10x Faster")
+4. **Use Cases**: Real-world applications (e.g., "Building an E-commerce Product Catalog with SonicJS")
+5. **Migration Guides**: From other CMSs (e.g., "Migrating from WordPress to SonicJS")
+6. **Best Practices**: Industry guidance (e.g., "Headless CMS Security Best Practices")
+
+### 3. Documentation SEO Optimization
+Improve the www/ docs site for search visibility:
+
+- Add proper meta tags to all pages
+- Implement structured data (JSON-LD)
+- Create/update sitemap.xml
+- Optimize robots.txt
+- Add OpenGraph and Twitter card meta tags
+- Improve internal linking
+- Add breadcrumb navigation with schema markup
+
+### 4. Discord-to-Forum Sync (Real Content)
+Help set up systems to surface real Discord discussions:
+
+- Create searchable archives of helpful Discord conversations
+- Transform Q&A threads into FAQ content
+- Surface community solutions as documentation
+- Attribute real users properly
+
+### 5. Technical SEO Tasks
+- Audit site performance (Core Web Vitals)
+- Check mobile responsiveness
+- Verify crawlability
+- Fix broken links
+- Optimize images with alt text
+- Implement proper heading hierarchy
+
+## Target Keywords
+
+### Primary Keywords (High Priority)
+- headless cms cloudflare
+- edge cms
+- typescript headless cms
+- cloudflare workers cms
+- hono cms
+- d1 database cms
+- serverless cms
+
+### Secondary Keywords
+- headless cms for developers
+- open source headless cms
+- api-first cms
+- jamstack cms
+- cloudflare d1 content management
+- edge-first content management
+
+### Long-tail Opportunities
+- how to build cms on cloudflare workers
+- best headless cms for cloudflare
+- typescript content management system
+- self-hosted headless cms cloudflare
+- htmx admin panel cms
+
+## Content Calendar Suggestions
+
+### Week 1-2: Foundation
+- SEO audit of existing docs
+- Add sitemap.xml and robots.txt
+- Implement OpenGraph tags across all pages
+
+### Week 3-4: Comparison Content
+- "SonicJS vs Strapi" comparison post
+- "SonicJS vs Sanity" comparison post
+- "Why Choose an Edge-First CMS" thought leadership
+
+### Week 5-6: Tutorial Content
+- "Getting Started with SonicJS" comprehensive guide
+- "Building Your First API with SonicJS"
+- "Deploying SonicJS to Cloudflare Workers"
+
+### Week 7-8: Advanced Content
+- "SonicJS Plugin Development Guide"
+- "Authentication and Authorization in SonicJS"
+- "Performance Optimization for Edge CMS"
+
+## Commands
+
+When invoked, I can help with:
+
+1. `/seo audit` - Audit current SEO status of www site
+2. `/seo keywords` - Generate keyword research report
+3. `/seo blog [topic]` - Generate a blog post on specified topic
+4. `/seo meta [page]` - Generate optimized meta tags for a page
+5. `/seo sitemap` - Create/update sitemap.xml
+6. `/seo schema [type]` - Generate JSON-LD structured data
+
+## Quality Guidelines
+
+- **Never use AI-generated filler content** - All content must provide genuine value
+- **Include real code examples** - Working, tested code snippets
+- **Be technically accurate** - Verify all claims against SonicJS capabilities
+- **Natural keyword usage** - No keyword stuffing
+- **Cite sources** - Link to official docs, benchmarks, and studies
+- **Update regularly** - Keep content fresh and accurate
+
+## SonicJS Key Differentiators (Use in Content)
+
+1. **Edge-First**: Runs on Cloudflare Workers for global low-latency
+2. **TypeScript-Native**: Full type safety, no JavaScript escape hatches
+3. **Zero Cold Starts**: Cloudflare Workers architecture
+4. **Built-in Storage**: D1 (database) + R2 (files) integration
+5. **HTMX Admin**: Modern, fast admin UI without heavy JavaScript
+6. **Plugin System**: Extensible architecture
+7. **Open Source**: MIT licensed, community-driven

--- a/www/public/robots.txt
+++ b/www/public/robots.txt
@@ -1,0 +1,11 @@
+# SonicJS Documentation - robots.txt
+# https://sonicjs.com
+
+User-agent: *
+Allow: /
+
+# Sitemap location
+Sitemap: https://sonicjs.com/sitemap.xml
+
+# Crawl-delay for polite crawling (optional)
+Crawl-delay: 1

--- a/www/src/app/layout.tsx
+++ b/www/src/app/layout.tsx
@@ -11,11 +11,65 @@ import allSections from './allSections.json'
 export const metadata: Metadata = {
   title: {
     template: '%s - SonicJS Documentation',
-    default: 'SonicJS - Modern Headless CMS',
+    default: 'SonicJS - Modern Headless CMS for Cloudflare Workers',
   },
-  description: 'SonicJS is a modern, blazingly fast headless CMS built with TypeScript, Hono, and Cloudflare Workers.',
+  description:
+    'SonicJS is a modern, blazingly fast headless CMS built with TypeScript, Hono, and Cloudflare Workers. Deploy globally with edge performance, D1 database, and R2 storage.',
+  keywords: [
+    'headless cms',
+    'cloudflare workers',
+    'typescript cms',
+    'edge cms',
+    'hono',
+    'd1 database',
+    'serverless cms',
+    'api-first cms',
+    'open source cms',
+  ],
+  authors: [{ name: 'SonicJS Team' }],
+  creator: 'SonicJS',
+  publisher: 'SonicJS',
   icons: {
     icon: '/favicon.svg',
+    apple: '/sonicjs-favicon.png',
+  },
+  openGraph: {
+    type: 'website',
+    locale: 'en_US',
+    url: 'https://sonicjs.com',
+    siteName: 'SonicJS',
+    title: 'SonicJS - Modern Headless CMS for Cloudflare Workers',
+    description:
+      'Build blazingly fast content APIs with SonicJS. TypeScript-first headless CMS built for Cloudflare Workers with D1 database and R2 storage.',
+    images: [
+      {
+        url: 'https://sonicjs.com/sonicjs-discord.png',
+        width: 1200,
+        height: 630,
+        alt: 'SonicJS - Modern Headless CMS',
+      },
+    ],
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: 'SonicJS - Modern Headless CMS for Cloudflare Workers',
+    description:
+      'Build blazingly fast content APIs with SonicJS. TypeScript-first headless CMS built for Cloudflare Workers.',
+    images: ['https://sonicjs.com/sonicjs-discord.png'],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-video-preview': -1,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+    },
+  },
+  alternates: {
+    canonical: 'https://sonicjs.com',
   },
 }
 

--- a/www/src/app/sitemap.ts
+++ b/www/src/app/sitemap.ts
@@ -1,0 +1,66 @@
+import { MetadataRoute } from 'next'
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = 'https://sonicjs.com'
+  const currentDate = new Date().toISOString()
+
+  // Main documentation pages with their priorities
+  const pages = [
+    // Homepage - highest priority
+    { url: '', priority: 1.0, changeFrequency: 'weekly' as const },
+
+    // Getting started - high priority
+    { url: '/quickstart', priority: 0.9, changeFrequency: 'weekly' as const },
+    { url: '/installation', priority: 0.9, changeFrequency: 'weekly' as const },
+
+    // Core concepts - high priority
+    { url: '/architecture', priority: 0.8, changeFrequency: 'monthly' as const },
+    { url: '/collections', priority: 0.8, changeFrequency: 'weekly' as const },
+    { url: '/database', priority: 0.8, changeFrequency: 'monthly' as const },
+    { url: '/api', priority: 0.8, changeFrequency: 'weekly' as const },
+
+    // Features - medium-high priority
+    { url: '/authentication', priority: 0.7, changeFrequency: 'monthly' as const },
+    { url: '/routing', priority: 0.7, changeFrequency: 'monthly' as const },
+    { url: '/templating', priority: 0.7, changeFrequency: 'monthly' as const },
+    { url: '/plugins', priority: 0.7, changeFrequency: 'weekly' as const },
+    { url: '/plugins/core', priority: 0.6, changeFrequency: 'monthly' as const },
+    { url: '/plugins/development', priority: 0.6, changeFrequency: 'monthly' as const },
+    { url: '/caching', priority: 0.7, changeFrequency: 'monthly' as const },
+    { url: '/attachments', priority: 0.7, changeFrequency: 'monthly' as const },
+    { url: '/webhooks', priority: 0.7, changeFrequency: 'monthly' as const },
+
+    // Reference - medium priority
+    { url: '/deployment', priority: 0.7, changeFrequency: 'monthly' as const },
+    { url: '/errors', priority: 0.6, changeFrequency: 'monthly' as const },
+    { url: '/pagination', priority: 0.6, changeFrequency: 'monthly' as const },
+    { url: '/testing', priority: 0.6, changeFrequency: 'monthly' as const },
+    { url: '/sdks', priority: 0.6, changeFrequency: 'monthly' as const },
+    { url: '/telemetry', priority: 0.5, changeFrequency: 'monthly' as const },
+
+    // Examples and guides
+    { url: '/examples', priority: 0.7, changeFrequency: 'weekly' as const },
+
+    // Community and support
+    { url: '/faq', priority: 0.6, changeFrequency: 'weekly' as const },
+    { url: '/community', priority: 0.6, changeFrequency: 'monthly' as const },
+    { url: '/contributing', priority: 0.5, changeFrequency: 'monthly' as const },
+    { url: '/contacts', priority: 0.5, changeFrequency: 'monthly' as const },
+
+    // Other pages
+    { url: '/conversations', priority: 0.5, changeFrequency: 'monthly' as const },
+    { url: '/messages', priority: 0.5, changeFrequency: 'monthly' as const },
+    { url: '/groups', priority: 0.5, changeFrequency: 'monthly' as const },
+
+    // Updates
+    { url: '/changelog', priority: 0.6, changeFrequency: 'weekly' as const },
+    { url: '/roadmap', priority: 0.6, changeFrequency: 'monthly' as const },
+  ]
+
+  return pages.map((page) => ({
+    url: `${baseUrl}${page.url}`,
+    lastModified: currentDate,
+    changeFrequency: page.changeFrequency,
+    priority: page.priority,
+  }))
+}


### PR DESCRIPTION
## Summary

- Add comprehensive SEO metadata to www site (OpenGraph, Twitter cards, keywords, robots directives)
- Create `robots.txt` for search engine crawler directives
- Add dynamic `sitemap.ts` covering all 32 documentation pages with proper priorities
- Create SEO expert sub-agent commands for AI-assisted content generation

## SEO Improvements

### Technical SEO
- **robots.txt**: Allows all crawlers, specifies sitemap location
- **sitemap.ts**: Dynamic sitemap with all doc pages, proper priorities (1.0 for homepage, 0.9 for quickstart, etc.)
- **Enhanced metadata**: OpenGraph tags, Twitter cards, keywords array, canonical URLs

### Sub-Agent Commands
| Command | Purpose |
|---------|---------|
| `/seo` | Main SEO expert agent with strategy overview |
| `/seo-audit` | Comprehensive SEO audit checklist |
| `/seo-blog [topic]` | Generate SEO-optimized blog posts |
| `/seo-keywords` | Keyword research and competitor analysis |
| `/seo-sitemap` | Sitemap creation and management |
| `/seo-discord-sync` | Surface real Discord discussions as searchable content |

## Test plan

- [ ] Verify sitemap renders at `/sitemap.xml`
- [ ] Verify robots.txt is accessible at `/robots.txt`
- [ ] Check OpenGraph tags render correctly (use Facebook debugger or similar)
- [ ] Test Twitter card preview
- [ ] Verify sub-agent commands are accessible via `/seo` etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)