### PR TITLE
test: unskip Collections and Content Management e2e tests

### DIFF
--- a/tests/e2e/04-collections.spec.ts
+++ b/tests/e2e/04-collections.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { loginAsAdmin, navigateToAdminSection, createTestCollection, deleteTestCollection, TEST_DATA } from './utils/test-helpers';
 
-test.describe.skip('Collections Management', () => {
+test.describe('Collections Management', () => {
   // Run tests sequentially to avoid database conflicts
   test.describe.configure({ mode: 'serial' });
 

--- a/tests/e2e/05-content.spec.ts
+++ b/tests/e2e/05-content.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { loginAsAdmin, navigateToAdminSection, waitForHTMX, ensureTestContentExists } from './utils/test-helpers';
 
-test.describe.skip('Content Management', () => {
+test.describe('Content Management', () => {
   test.beforeEach(async ({ page }) => {
     await loginAsAdmin(page);
     await ensureTestContentExists(page);


### PR DESCRIPTION
## Summary
- Unskipped `tests/e2e/04-collections.spec.ts` - Collections Management tests
- Unskipped `tests/e2e/05-content.spec.ts` - Content Management tests

These tests were previously skipped due to the "SQLITE_ERROR: table content has no column named created_by" bug which was fixed in commit 12dd9ed8 (PR #404).

## Context
Issue #423 reported the same bug. After analysis, I confirmed it's a duplicate of #399 which was already fixed. The issue has been closed as a duplicate with appropriate documentation.

## Test plan
- [x] Unit tests pass (360 passed, 328 skipped)
- [x] Type checks pass
- [x] Commit follows project conventions

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)