### PR TITLE
feat(www): add SEO structured data and breadcrumbs

### DIFF
--- a/www/src/app/layout.tsx
+++ b/www/src/app/layout.tsx
@@ -10,7 +10,7 @@ import allSections from './allSections.json'
 
 export const metadata: Metadata = {
   title: {
-    template: '%s - SonicJS Documentation',
+    template: '%s | SonicJS Docs',
     default: 'SonicJS - Modern Headless CMS for Cloudflare Workers',
   },
   description:
@@ -93,6 +93,67 @@ export default function RootLayout({
             gtag('config', 'G-FWS35H2E1W');
           `}
         </Script>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              '@context': 'https://schema.org',
+              '@graph': [
+                {
+                  '@type': 'Organization',
+                  '@id': 'https://sonicjs.com/#organization',
+                  name: 'SonicJS',
+                  url: 'https://sonicjs.com',
+                  logo: {
+                    '@type': 'ImageObject',
+                    url: 'https://sonicjs.com/sonicjs-favicon.png',
+                  },
+                  sameAs: [
+                    'https://github.com/lane711/sonicjs',
+                    'https://twitter.com/nicholasbarger',
+                    'https://discord.gg/SV4Mqsss8f',
+                  ],
+                },
+                {
+                  '@type': 'SoftwareApplication',
+                  '@id': 'https://sonicjs.com/#software',
+                  name: 'SonicJS',
+                  description:
+                    'A modern, blazingly fast headless CMS built with TypeScript, Hono, and Cloudflare Workers.',
+                  applicationCategory: 'DeveloperApplication',
+                  operatingSystem: 'Cross-platform',
+                  offers: {
+                    '@type': 'Offer',
+                    price: '0',
+                    priceCurrency: 'USD',
+                  },
+                  author: {
+                    '@id': 'https://sonicjs.com/#organization',
+                  },
+                  programmingLanguage: 'TypeScript',
+                  runtimePlatform: 'Cloudflare Workers',
+                },
+                {
+                  '@type': 'WebSite',
+                  '@id': 'https://sonicjs.com/#website',
+                  url: 'https://sonicjs.com',
+                  name: 'SonicJS Documentation',
+                  publisher: {
+                    '@id': 'https://sonicjs.com/#organization',
+                  },
+                  potentialAction: {
+                    '@type': 'SearchAction',
+                    target: {
+                      '@type': 'EntryPoint',
+                      urlTemplate: 'https://sonicjs.com/?q={search_term_string}',
+                    },
+                    'query-input': 'required name=search_term_string',
+                  },
+                },
+              ],
+            }),
+          }}
+        />
       </head>
       <body className="flex min-h-full bg-white antialiased dark:bg-zinc-900">
         <Providers>

--- a/www/src/components/Breadcrumbs.tsx
+++ b/www/src/components/Breadcrumbs.tsx
@@ -1,0 +1,110 @@
+'use client'
+
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { navigation } from '@/components/Navigation'
+
+interface BreadcrumbItem {
+  name: string
+  href: string
+}
+
+function getBreadcrumbs(pathname: string): BreadcrumbItem[] {
+  const breadcrumbs: BreadcrumbItem[] = [{ name: 'Home', href: '/' }]
+
+  if (pathname === '/') {
+    return breadcrumbs
+  }
+
+  // Find the current page in navigation
+  for (const group of navigation) {
+    for (const link of group.links) {
+      if (link.href === pathname) {
+        breadcrumbs.push({
+          name: group.title,
+          href: group.links[0].href,
+        })
+        if (link.title !== group.title) {
+          breadcrumbs.push({
+            name: link.title,
+            href: link.href,
+          })
+        }
+        return breadcrumbs
+      }
+    }
+  }
+
+  // Fallback for pages not in navigation
+  const segments = pathname.split('/').filter(Boolean)
+  let currentPath = ''
+  for (const segment of segments) {
+    currentPath += `/${segment}`
+    breadcrumbs.push({
+      name: segment.charAt(0).toUpperCase() + segment.slice(1).replace(/-/g, ' '),
+      href: currentPath,
+    })
+  }
+
+  return breadcrumbs
+}
+
+export function Breadcrumbs() {
+  const pathname = usePathname()
+  const breadcrumbs = getBreadcrumbs(pathname)
+
+  // Don't show breadcrumbs on homepage
+  if (pathname === '/') {
+    return null
+  }
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: breadcrumbs.map((item, index) => ({
+      '@type': 'ListItem',
+      position: index + 1,
+      name: item.name,
+      item: `https://sonicjs.com${item.href}`,
+    })),
+  }
+
+  return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <nav aria-label="Breadcrumb" className="mt-4 mb-4">
+        <ol className="flex items-center space-x-2 text-sm text-zinc-500 dark:text-zinc-400">
+          {breadcrumbs.map((item, index) => (
+            <li key={item.href} className="flex items-center">
+              {index > 0 && (
+                <svg
+                  className="mx-2 h-4 w-4 flex-shrink-0"
+                  fill="currentColor"
+                  viewBox="0 0 20 20"
+                  aria-hidden="true"
+                >
+                  <path d="M5.555 17.776l8-16 .894.448-8 16-.894-.448z" />
+                </svg>
+              )}
+              {index === breadcrumbs.length - 1 ? (
+                <span className="text-zinc-900 dark:text-white font-medium">
+                  {item.name}
+                </span>
+              ) : (
+                <Link
+                  href={item.href}
+                  className="hover:text-zinc-900 dark:hover:text-white transition-colors"
+                >
+                  {item.name}
+                </Link>
+              )}
+            </li>
+          ))}
+        </ol>
+      </nav>
+    </>
+  )
+}

--- a/www/src/components/Layout.tsx
+++ b/www/src/components/Layout.tsx
@@ -4,6 +4,7 @@ import { motion } from 'framer-motion'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 
+import { Breadcrumbs } from '@/components/Breadcrumbs'
 import { Footer } from '@/components/Footer'
 import { Header } from '@/components/Header'
 import { Logo } from '@/components/Logo'
@@ -41,6 +42,7 @@ export function Layout({
           </div>
         </motion.header>
         <div className="relative flex h-full flex-col px-4 pt-14 sm:px-6 lg:px-8">
+          <Breadcrumbs />
           <main className="flex-auto">{children}</main>
           <Footer />
         </div>


### PR DESCRIPTION
## Summary
- Add JSON-LD structured data (Organization, SoftwareApplication, WebSite schemas)
- Fix duplicate title pattern from `%s - SonicJS Documentation` to `%s | SonicJS Docs`
- Add Breadcrumbs component with BreadcrumbList schema for rich snippets in search results

## Changes
- `www/src/app/layout.tsx` - Added JSON-LD schemas and fixed title template
- `www/src/components/Layout.tsx` - Added Breadcrumbs component
- `www/src/components/Breadcrumbs.tsx` - New component with visual breadcrumbs + schema

## SEO Improvements
| Issue | Before | After |
|-------|--------|-------|
| JSON-LD Structured Data | ❌ Missing | ✅ Organization, SoftwareApplication, WebSite |
| Title Pattern | "Page - SonicJS - SonicJS Documentation" | "Page | SonicJS Docs" |
| Breadcrumbs | ❌ Missing | ✅ Visual + BreadcrumbList schema |

## Test plan
- [ ] Verify build passes
- [ ] Check JSON-LD output in page source
- [ ] Verify breadcrumbs display correctly on documentation pages
- [ ] Test with Google Rich Results Test tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)