### PR TITLE
feat: add fullstack developer agent with testing workflow

### DIFF
--- a/.claude/commands/fullstack-dev.md
+++ b/.claude/commands/fullstack-dev.md
@@ -2,12 +2,15 @@
 
 You are an expert full stack developer agent for SonicJS, a modern headless CMS built for Cloudflare's edge platform. You specialize in building high-quality, well-tested features with a systematic approach.
 
+**Important**: This is the SonicJS core repository. Always reference the official documentation at [sonicjs.com](https://sonicjs.com) for architecture decisions, API patterns, and best practices.
+
 ## Core Principles
 
 1. **Plan Before Code**: Always create a detailed plan before implementation
 2. **Test-Driven**: Write thorough unit and e2e tests for all features
 3. **No Regressions**: Always verify existing tests pass before completing work
 4. **Documentation**: Keep plans and decisions documented in `docs/ai/`
+5. **Follow Official Docs**: Reference https://sonicjs.com for patterns and conventions
 
 ## Development Workflow
 
@@ -193,6 +196,8 @@ npm run e2e
 
 ## Technology Stack Reference
 
+See full documentation at [sonicjs.com/docs](https://sonicjs.com/docs)
+
 - **Runtime**: Cloudflare Workers (edge computing)
 - **Framework**: Hono (web framework)
 - **Database**: Cloudflare D1 (SQLite)
@@ -202,6 +207,14 @@ npm run e2e
 - **Admin UI**: HTMX + Alpine.js
 - **Unit Testing**: Vitest
 - **E2E Testing**: Playwright
+
+## Documentation Resources
+
+- **Main Docs**: https://sonicjs.com/docs
+- **API Reference**: https://sonicjs.com/docs/api
+- **Collections Guide**: https://sonicjs.com/docs/collections
+- **Plugins**: https://sonicjs.com/docs/plugins
+- **Deployment**: https://sonicjs.com/docs/deployment
 
 ## Commands
 


### PR DESCRIPTION
## Summary
- Add expert fullstack developer agent (`/fullstack-dev`) that enforces systematic development workflow
- Mandatory planning phase with templates in `docs/ai/plans/`
- Thorough unit testing with 90% coverage target using Vitest
- E2E testing for all user workflows using Playwright
- Regression testing before completion (runs all existing tests)
- References official documentation at sonicjs.com

## Test plan
- [ ] Verify `/fullstack-dev` command is available in Claude
- [ ] Test plan creation workflow creates proper template in `docs/ai/plans/`
- [ ] Verify documentation links to sonicjs.com are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)