### PR TITLE
feat: add dependabot-manager agent for enabling e2e tests on dependency PRs

### DIFF
--- a/.claude/commands/dependabot-manager.md
+++ b/.claude/commands/dependabot-manager.md
@@ -1,0 +1,99 @@
+# Dependabot PR Manager Agent
+
+You are a specialized agent that manages Dependabot dependency update PRs. Your primary job is to enable e2e tests to run on Dependabot PRs by pushing a commit that changes the workflow actor from `dependabot[bot]` to a human actor, which grants access to repository secrets.
+
+## Background
+
+Dependabot PRs skip e2e tests in CI because:
+1. GitHub Actions checks `github.actor != 'dependabot[bot]'` to skip Cloudflare deployment steps
+2. This is a security feature - Dependabot doesn't have access to repository secrets
+3. When a human pushes to a Dependabot branch, subsequent workflow runs use the human as the actor
+
+## Workflow
+
+When invoked, follow these steps:
+
+### Step 1: List Open Dependabot PRs
+
+```bash
+gh pr list --author "app/dependabot" --state open --json number,title,headRefName,url
+```
+
+If no PRs are found, inform the user and exit.
+
+### Step 2: Display PRs for Selection
+
+Show the user the list of open Dependabot PRs with:
+- PR number
+- Title (dependency being updated)
+- Branch name
+- URL
+
+Ask the user which PR(s) they want to enable e2e tests for. Options:
+- A specific PR number
+- "all" to process all open Dependabot PRs
+- A comma-separated list of PR numbers
+
+### Step 3: Enable E2E Tests
+
+For each selected PR:
+
+1. **Fetch the branch**:
+   ```bash
+   git fetch origin <branch-name>
+   ```
+
+2. **Checkout the branch**:
+   ```bash
+   git checkout <branch-name>
+   ```
+
+3. **Create an empty commit** to trigger a new workflow run with human actor:
+   ```bash
+   git commit --allow-empty -m "ci: trigger e2e tests for Dependabot PR
+
+   This empty commit changes the workflow actor from dependabot[bot] to a human,
+   enabling access to repository secrets for e2e tests.
+
+   🤖 Generated with [Claude Code](https://claude.com/claude-code)"
+   ```
+
+4. **Push the commit**:
+   ```bash
+   git push origin <branch-name>
+   ```
+
+5. **Return to main branch**:
+   ```bash
+   git checkout main
+   ```
+
+### Step 4: Report Status
+
+After processing, report:
+- Which PRs were updated
+- Links to the PRs so the user can monitor the e2e test runs
+- Remind user that PRs still need manual review and merge
+
+## Usage Examples
+
+```
+/dependabot-manager              # List and interactively select PRs
+/dependabot-manager all          # Enable e2e for all open Dependabot PRs
+/dependabot-manager 123          # Enable e2e for specific PR #123
+/dependabot-manager 123,124,125  # Enable e2e for multiple specific PRs
+```
+
+## Important Notes
+
+1. **Security**: This agent only pushes empty commits - no code changes
+2. **Manual merge required**: PRs still require human review and merge
+3. **Re-run if needed**: If e2e tests fail, investigate the failure - don't just re-trigger
+4. **Rate limits**: Be mindful of GitHub API rate limits when processing many PRs
+
+## Error Handling
+
+- If `gh` CLI is not authenticated, prompt user to run `gh auth login`
+- If branch doesn't exist remotely, skip with warning
+- If push fails, check if user has write access to the repository
+- If no Dependabot PRs exist, inform user and exit gracefully


### PR DESCRIPTION
## Summary

- Adds a new `/dependabot-manager` Claude Code agent that enables e2e tests to run on Dependabot PRs
- Works by pushing an empty commit to Dependabot branches, which changes the workflow actor from `dependabot[bot]` to a human
- This grants access to repository secrets needed for Cloudflare deployment and e2e testing

## Background

Dependabot PRs currently skip e2e tests because `github.actor == 'dependabot[bot]'` triggers the skip condition in `pr-tests.yml`. This is a security feature since Dependabot doesn't have access to repository secrets.

When a human pushes to the same branch, subsequent workflow runs use the human as the actor, enabling full e2e testing.

## Usage

```bash
/dependabot-manager              # Interactive - list and select PRs
/dependabot-manager all          # Process all open Dependabot PRs  
/dependabot-manager 123          # Process specific PR #123
/dependabot-manager 123,124,125  # Process multiple PRs
```

## Test plan

- [ ] Invoke `/dependabot-manager` with an open Dependabot PR
- [ ] Verify empty commit is pushed to the Dependabot branch
- [ ] Confirm e2e tests run in the new workflow execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)