### PR TITLE
docs: add coding standards documentation for contributors

### DIFF
--- a/CODING_STANDARDS.md
+++ b/CODING_STANDARDS.md
@@ -1,0 +1,470 @@
+# SonicJS Coding Standards
+
+This document defines the coding standards for contributing to SonicJS. Following these standards ensures consistency across the codebase and makes it easier for everyone to contribute.
+
+## Naming Conventions
+
+### Summary Table
+
+| Element | Convention | Example |
+|---------|------------|---------|
+| Collection names | snake_case | `blog_posts`, `user_profiles` |
+| Schema field names | camelCase | `firstName`, `createdAt` |
+| Database columns | snake_case | `first_name`, `created_at` |
+| API responses | camelCase | `userId`, `createdAt` |
+| TypeScript variables | camelCase | `userData`, `isActive` |
+| TypeScript functions | camelCase | `getUserById`, `validateInput` |
+| Classes & Types | PascalCase | `UserService`, `BlogPost` |
+| Interfaces | PascalCase | `IUserRepository`, `ApiResponse` |
+| Constants | SCREAMING_SNAKE_CASE | `MAX_RETRIES`, `API_BASE_URL` |
+| File names | kebab-case | `user-service.ts`, `blog-posts.collection.ts` |
+| Enum values | PascalCase | `UserRole.Admin`, `Status.Active` |
+
+### Collection Names
+
+Collection names **must** be lowercase with underscores (snake_case). This is enforced by validation:
+
+```typescript
+// Correct
+name: 'blog_posts'
+name: 'user_profiles'
+name: 'order_items'
+
+// Incorrect
+name: 'blogPosts'      // No camelCase
+name: 'Blog_Posts'     // No uppercase
+name: 'blog-posts'     // No hyphens
+```
+
+**Validation regex:** `/^[a-z0-9_]+$/`
+
+### Schema Field Names
+
+Schema field names should use **camelCase** in the TypeScript definition:
+
+```typescript
+// Correct
+export const blogPostsCollection: CollectionConfig = {
+  name: 'blog_posts',
+  schema: {
+    type: 'object',
+    properties: {
+      title: { type: 'string' },
+      featuredImage: { type: 'string', format: 'media' },
+      publishedAt: { type: 'string', format: 'date-time' },
+      metaDescription: { type: 'string' },
+    },
+  },
+}
+
+// Incorrect - don't use snake_case for schema properties
+properties: {
+  featured_image: { type: 'string' },  // Wrong
+  published_at: { type: 'string' },    // Wrong
+}
+```
+
+### Database Columns
+
+Database column names use **snake_case** (SQL convention). Drizzle ORM maps camelCase TypeScript properties to snake_case columns:
+
+```typescript
+// TypeScript property -> SQL column
+firstName: text('first_name').notNull(),
+lastName: text('last_name').notNull(),
+createdAt: integer('created_at'),
+updatedAt: integer('updated_at'),
+isActive: integer('is_active', { mode: 'boolean' }),
+```
+
+### API Responses
+
+API responses should use **camelCase** (JavaScript convention). Transform database results at the API boundary:
+
+```typescript
+// Correct - API response uses camelCase
+{
+  "id": "123",
+  "userId": "user_456",
+  "createdAt": "2024-01-15T10:30:00Z",
+  "updatedAt": "2024-01-15T10:30:00Z",
+  "firstName": "John",
+  "lastName": "Doe"
+}
+
+// Incorrect - don't expose snake_case to API consumers
+{
+  "user_id": "user_456",     // Wrong
+  "created_at": "...",       // Wrong
+  "first_name": "John"       // Wrong
+}
+```
+
+### TypeScript Variables and Functions
+
+Use **camelCase** for variables and functions:
+
+```typescript
+// Correct
+const userData = await getUserById(userId)
+const isValidEmail = validateEmail(email)
+let itemCount = 0
+
+// Incorrect
+const user_data = await get_user_by_id(user_id)  // Wrong
+const IsValidEmail = validateEmail(email)         // Wrong (PascalCase)
+```
+
+### Classes, Types, and Interfaces
+
+Use **PascalCase** for classes, types, and interfaces:
+
+```typescript
+// Correct
+class UserService { }
+type BlogPost = { title: string; content: string }
+interface ApiResponse<T> { data: T; status: number }
+
+// Incorrect
+class userService { }        // Wrong
+type blogPost = { }          // Wrong
+interface apiResponse { }    // Wrong
+```
+
+### Constants
+
+Use **SCREAMING_SNAKE_CASE** for constants:
+
+```typescript
+// Correct
+const MAX_RETRY_ATTEMPTS = 3
+const API_BASE_URL = 'https://api.example.com'
+const DEFAULT_PAGE_SIZE = 20
+
+// Incorrect
+const maxRetryAttempts = 3   // Wrong (looks like a variable)
+const ApiBaseUrl = '...'     // Wrong
+```
+
+### File Names
+
+Use **kebab-case** for file names:
+
+```
+// Correct
+user-service.ts
+blog-posts.collection.ts
+api-response.types.ts
+auth.middleware.ts
+
+// Incorrect
+userService.ts              // Wrong (camelCase)
+BlogPosts.collection.ts     // Wrong (PascalCase)
+user_service.ts             // Wrong (snake_case)
+```
+
+## Code Style
+
+### TypeScript
+
+- **Always use TypeScript** with proper type annotations
+- Avoid `any` type - use `unknown` if the type is truly unknown
+- Prefer interfaces over type aliases for object shapes
+- Use generics for reusable components
+
+```typescript
+// Correct
+function getUser(id: string): Promise<User | null> {
+  // ...
+}
+
+// Incorrect
+function getUser(id): any {  // Missing types
+  // ...
+}
+```
+
+### Async/Await
+
+- Prefer `async/await` over `.then()` chains
+- Always handle errors with try/catch or error boundaries
+
+```typescript
+// Correct
+async function fetchData() {
+  try {
+    const result = await api.getData()
+    return result
+  } catch (error) {
+    logger.error('Failed to fetch data', error)
+    throw error
+  }
+}
+
+// Avoid
+function fetchData() {
+  return api.getData()
+    .then(result => result)
+    .catch(error => {
+      logger.error(error)
+      throw error
+    })
+}
+```
+
+### Imports
+
+Organize imports in this order:
+1. Node.js built-in modules
+2. External dependencies
+3. Internal modules (absolute paths)
+4. Relative imports
+
+```typescript
+// 1. Built-in modules
+import { readFile } from 'fs/promises'
+
+// 2. External dependencies
+import { Hono } from 'hono'
+import { drizzle } from 'drizzle-orm/d1'
+
+// 3. Internal modules
+import { UserService } from '@/services/user-service'
+import { validateInput } from '@/utils/validation'
+
+// 4. Relative imports
+import { localHelper } from './helpers'
+import type { LocalType } from './types'
+```
+
+### Error Handling
+
+- Use custom error classes for domain-specific errors
+- Include meaningful error messages
+- Log errors with context
+
+```typescript
+// Correct
+class NotFoundError extends Error {
+  constructor(resource: string, id: string) {
+    super(`${resource} with id '${id}' not found`)
+    this.name = 'NotFoundError'
+  }
+}
+
+// Usage
+throw new NotFoundError('User', userId)
+```
+
+### Comments
+
+- Write self-documenting code - minimize comments
+- Use JSDoc for public APIs
+- Explain "why" not "what"
+
+```typescript
+// Good - explains why
+// Cache for 5 minutes to reduce database load during peak hours
+const CACHE_TTL = 300
+
+// Bad - explains what (obvious from code)
+// Set cache TTL to 300
+const CACHE_TTL = 300
+```
+
+## Project-Specific Patterns
+
+### Collection Definitions
+
+Follow this pattern for collection definitions:
+
+```typescript
+import { CollectionConfig } from '@sonicjs/core'
+
+export const blogPostsCollection: CollectionConfig = {
+  name: 'blog_posts',  // snake_case
+  schema: {
+    type: 'object',
+    properties: {
+      title: {
+        type: 'string',
+        title: 'Title',
+        required: true,
+      },
+      content: {
+        type: 'string',
+        title: 'Content',
+        format: 'richtext',
+      },
+      featuredImage: {  // camelCase
+        type: 'string',
+        title: 'Featured Image',
+        format: 'media',
+      },
+      publishedAt: {  // camelCase
+        type: 'string',
+        title: 'Published At',
+        format: 'date-time',
+      },
+    },
+  },
+  access: {
+    read: () => true,
+    create: ({ user }) => !!user,
+    update: ({ user }) => !!user,
+    delete: ({ user }) => user?.role === 'admin',
+  },
+}
+```
+
+### Route Handlers
+
+Follow this pattern for Hono route handlers:
+
+```typescript
+import { Hono } from 'hono'
+import type { Context } from 'hono'
+
+const app = new Hono()
+
+app.get('/users/:id', async (c: Context) => {
+  const { id } = c.req.param()
+
+  try {
+    const user = await userService.getById(id)
+
+    if (!user) {
+      return c.json({ error: 'User not found' }, 404)
+    }
+
+    return c.json({ data: user })  // camelCase in response
+  } catch (error) {
+    logger.error('Failed to get user', { id, error })
+    return c.json({ error: 'Internal server error' }, 500)
+  }
+})
+```
+
+### Middleware
+
+Follow this pattern for middleware:
+
+```typescript
+import type { MiddlewareHandler } from 'hono'
+
+export const authMiddleware: MiddlewareHandler = async (c, next) => {
+  const token = c.req.header('Authorization')?.replace('Bearer ', '')
+
+  if (!token) {
+    return c.json({ error: 'Unauthorized' }, 401)
+  }
+
+  try {
+    const user = await verifyToken(token)
+    c.set('user', user)
+    await next()
+  } catch (error) {
+    return c.json({ error: 'Invalid token' }, 401)
+  }
+}
+```
+
+## Formatting and Linting
+
+### Prettier
+
+Prettier runs automatically on commit. Configuration is in `.prettierrc`:
+
+```json
+{
+  "semi": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5"
+}
+```
+
+### ESLint
+
+ESLint rules must pass. Run before committing:
+
+```bash
+npm run lint
+```
+
+### Pre-commit Hooks
+
+Pre-commit hooks automatically:
+- Format code with Prettier
+- Run ESLint
+- Run type checking
+
+## Testing Standards
+
+### Test File Location
+
+Place test files next to the code they test:
+
+```
+src/
+  services/
+    user-service.ts
+    user-service.test.ts    # Unit tests
+  routes/
+    api.ts
+    api.test.ts
+```
+
+Or in a `__tests__` directory for larger test suites:
+
+```
+src/
+  services/
+    user-service.ts
+    __tests__/
+      user-service.test.ts
+      user-service.integration.test.ts
+```
+
+### Test Naming
+
+Use descriptive test names:
+
+```typescript
+describe('UserService', () => {
+  describe('getById', () => {
+    it('returns user when found', async () => {
+      // ...
+    })
+
+    it('returns null when user does not exist', async () => {
+      // ...
+    })
+
+    it('throws error when database connection fails', async () => {
+      // ...
+    })
+  })
+})
+```
+
+## Quick Reference
+
+```
+Collection names:     snake_case     blog_posts
+Schema fields:        camelCase      featuredImage
+Database columns:     snake_case     featured_image
+API responses:        camelCase      featuredImage
+Variables:            camelCase      userData
+Functions:            camelCase      getUserById
+Classes/Types:        PascalCase     UserService
+Constants:            SNAKE_CASE     MAX_RETRIES
+Files:                kebab-case     user-service.ts
+```
+
+## Questions?
+
+If you have questions about these standards:
+- Check [existing issues](https://github.com/lane711/sonicjs/issues)
+- Ask in [GitHub Discussions](https://github.com/lane711/sonicjs/discussions)
+- Join our [Discord](https://discord.gg/8bMy6bv3sZ)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,6 +47,7 @@ We appreciate every developer who wants to contribute. To ensure the best experi
 - **Documentation**: Public APIs must be documented
 - **Formatting**: Use Prettier (runs automatically on commit)
 - **Linting**: ESLint rules must pass
+- **Naming Conventions**: See our [Coding Standards Guide](https://sonicjs.com/coding-standards) for detailed naming conventions and code style guidelines
 
 ## Pull Request Checklist
 

--- a/www/package.json
+++ b/www/package.json
@@ -8,6 +8,7 @@
     "npm": ">=10.0.0"
   },
   "scripts": {
+    "predev": "node scripts/generate-sections.mjs",
     "dev": "next dev -p 3010",
     "prebuild": "node scripts/generate-sections.mjs",
     "build": "next build",

--- a/www/src/app/coding-standards/page.mdx
+++ b/www/src/app/coding-standards/page.mdx
@@ -1,0 +1,502 @@
+export const metadata = {
+  title: 'Coding Standards - SonicJS',
+  description: 'Coding standards and naming conventions for contributing to SonicJS',
+}
+
+export const sections = [
+  { title: 'Naming Conventions', id: 'naming-conventions' },
+  { title: 'Collection Names', id: 'collection-names' },
+  { title: 'Schema Field Names', id: 'schema-field-names' },
+  { title: 'Database Columns', id: 'database-columns' },
+  { title: 'API Responses', id: 'api-responses' },
+  { title: 'TypeScript Conventions', id: 'typescript-conventions' },
+  { title: 'File Names', id: 'file-names' },
+  { title: 'Code Style', id: 'code-style' },
+  { title: 'Project Patterns', id: 'project-patterns' },
+  { title: 'Testing Standards', id: 'testing-standards' },
+]
+
+# Coding Standards
+
+Consistent coding standards ensure a maintainable codebase and make it easier for everyone to contribute. {{ className: 'lead' }}
+
+<FeatureGrid
+  features={[
+    {
+      icon: '📝',
+      title: 'Naming Conventions',
+      description: 'Clear rules for naming collections, fields, variables, and files',
+    },
+    {
+      icon: '🔄',
+      title: 'Consistency',
+      description: 'camelCase for JavaScript, snake_case for database/collections',
+    },
+    {
+      icon: '✨',
+      title: 'TypeScript First',
+      description: 'All code must be properly typed with TypeScript',
+    },
+    {
+      icon: '🧪',
+      title: 'Test Coverage',
+      description: 'New features must include comprehensive tests',
+    },
+  ]}
+  columns={2}
+/>
+
+---
+
+## Naming Conventions
+
+SonicJS follows industry-standard naming conventions with clear boundaries between JavaScript/TypeScript code and database layers.
+
+### Quick Reference
+
+| Element | Convention | Example |
+|---------|------------|---------|
+| Collection names | snake_case | `blog_posts`, `user_profiles` |
+| Schema field names | camelCase | `firstName`, `createdAt` |
+| Database columns | snake_case | `first_name`, `created_at` |
+| API responses | camelCase | `userId`, `createdAt` |
+| TypeScript variables | camelCase | `userData`, `isActive` |
+| TypeScript functions | camelCase | `getUserById`, `validateInput` |
+| Classes & Types | PascalCase | `UserService`, `BlogPost` |
+| Constants | SCREAMING_SNAKE_CASE | `MAX_RETRIES`, `API_BASE_URL` |
+| File names | kebab-case | `user-service.ts` |
+
+---
+
+## Collection Names
+
+Collection names **must** be lowercase with underscores (snake_case). This is enforced by validation.
+
+<CodeGroup title="Collection Names">
+
+```typescript {{title: 'Correct'}}
+// All lowercase with underscores
+name: 'blog_posts'
+name: 'user_profiles'
+name: 'order_items'
+```
+
+```typescript {{title: 'Incorrect'}}
+// These will fail validation
+name: 'blogPosts'      // No camelCase
+name: 'Blog_Posts'     // No uppercase
+name: 'blog-posts'     // No hyphens
+```
+
+</CodeGroup>
+
+<Note>
+Collection names are validated with the regex `/^[a-z0-9_]+$/`. Only lowercase letters, numbers, and underscores are allowed.
+</Note>
+
+---
+
+## Schema Field Names
+
+Schema field names should use **camelCase** in the TypeScript definition:
+
+<CodeGroup title="Schema Fields">
+
+```typescript {{title: 'Correct'}}
+export const blogPostsCollection: CollectionConfig = {
+  name: 'blog_posts',
+  schema: {
+    type: 'object',
+    properties: {
+      title: { type: 'string' },
+      featuredImage: { type: 'string', format: 'media' },
+      publishedAt: { type: 'string', format: 'date-time' },
+      metaDescription: { type: 'string' },
+    },
+  },
+}
+```
+
+```typescript {{title: 'Incorrect'}}
+// Don't use snake_case for schema properties
+properties: {
+  featured_image: { type: 'string' },  // Wrong
+  published_at: { type: 'string' },    // Wrong
+  meta_description: { type: 'string' } // Wrong
+}
+```
+
+</CodeGroup>
+
+---
+
+## Database Columns
+
+Database column names use **snake_case** (SQL convention). Drizzle ORM maps camelCase TypeScript properties to snake_case columns:
+
+```typescript
+// TypeScript property -> SQL column
+firstName: text('first_name').notNull(),
+lastName: text('last_name').notNull(),
+createdAt: integer('created_at'),
+updatedAt: integer('updated_at'),
+isActive: integer('is_active', { mode: 'boolean' }),
+```
+
+---
+
+## API Responses
+
+API responses should use **camelCase** (JavaScript convention). Transform database results at the API boundary:
+
+<CodeGroup title="API Responses">
+
+```json {{title: 'Correct'}}
+{
+  "id": "123",
+  "userId": "user_456",
+  "createdAt": "2024-01-15T10:30:00Z",
+  "updatedAt": "2024-01-15T10:30:00Z",
+  "firstName": "John",
+  "lastName": "Doe"
+}
+```
+
+```json {{title: 'Incorrect'}}
+{
+  "user_id": "user_456",
+  "created_at": "2024-01-15T10:30:00Z",
+  "first_name": "John",
+  "last_name": "Doe"
+}
+```
+
+</CodeGroup>
+
+---
+
+## TypeScript Conventions
+
+### Variables and Functions
+
+Use **camelCase** for variables and functions:
+
+```typescript
+// Correct
+const userData = await getUserById(userId)
+const isValidEmail = validateEmail(email)
+let itemCount = 0
+
+// Incorrect
+const user_data = await get_user_by_id(user_id)  // Wrong
+const IsValidEmail = validateEmail(email)         // Wrong
+```
+
+### Classes, Types, and Interfaces
+
+Use **PascalCase** for classes, types, and interfaces:
+
+```typescript
+// Correct
+class UserService { }
+type BlogPost = { title: string; content: string }
+interface ApiResponse<T> { data: T; status: number }
+
+// Incorrect
+class userService { }        // Wrong
+type blogPost = { }          // Wrong
+```
+
+### Constants
+
+Use **SCREAMING_SNAKE_CASE** for constants:
+
+```typescript
+// Correct
+const MAX_RETRY_ATTEMPTS = 3
+const API_BASE_URL = 'https://api.example.com'
+const DEFAULT_PAGE_SIZE = 20
+
+// Incorrect
+const maxRetryAttempts = 3   // Looks like a variable
+```
+
+---
+
+## File Names
+
+Use **kebab-case** for file names:
+
+```
+// Correct
+user-service.ts
+blog-posts.collection.ts
+api-response.types.ts
+auth.middleware.ts
+
+// Incorrect
+userService.ts              // camelCase
+BlogPosts.collection.ts     // PascalCase
+user_service.ts             // snake_case
+```
+
+---
+
+## Code Style
+
+### TypeScript Requirements
+
+- **Always use TypeScript** with proper type annotations
+- Avoid `any` type - use `unknown` if the type is truly unknown
+- Prefer interfaces over type aliases for object shapes
+
+```typescript
+// Correct
+function getUser(id: string): Promise<User | null> {
+  // ...
+}
+
+// Incorrect
+function getUser(id): any {  // Missing types
+  // ...
+}
+```
+
+### Async/Await
+
+Prefer `async/await` over `.then()` chains:
+
+<CodeGroup title="Async Patterns">
+
+```typescript {{title: 'Preferred'}}
+async function fetchData() {
+  try {
+    const result = await api.getData()
+    return result
+  } catch (error) {
+    logger.error('Failed to fetch data', error)
+    throw error
+  }
+}
+```
+
+```typescript {{title: 'Avoid'}}
+function fetchData() {
+  return api.getData()
+    .then(result => result)
+    .catch(error => {
+      logger.error(error)
+      throw error
+    })
+}
+```
+
+</CodeGroup>
+
+### Import Organization
+
+Organize imports in this order:
+
+1. Node.js built-in modules
+2. External dependencies
+3. Internal modules (absolute paths)
+4. Relative imports
+
+```typescript
+// 1. Built-in modules
+import { readFile } from 'fs/promises'
+
+// 2. External dependencies
+import { Hono } from 'hono'
+import { drizzle } from 'drizzle-orm/d1'
+
+// 3. Internal modules
+import { UserService } from '@/services/user-service'
+import { validateInput } from '@/utils/validation'
+
+// 4. Relative imports
+import { localHelper } from './helpers'
+import type { LocalType } from './types'
+```
+
+---
+
+## Project Patterns
+
+### Collection Definitions
+
+<CodeGroup title="Collection Pattern">
+
+```typescript
+import { CollectionConfig } from '@sonicjs/core'
+
+export const blogPostsCollection: CollectionConfig = {
+  name: 'blog_posts',  // snake_case
+  schema: {
+    type: 'object',
+    properties: {
+      title: {
+        type: 'string',
+        title: 'Title',
+        required: true,
+      },
+      content: {
+        type: 'string',
+        title: 'Content',
+        format: 'richtext',
+      },
+      featuredImage: {  // camelCase
+        type: 'string',
+        title: 'Featured Image',
+        format: 'media',
+      },
+      publishedAt: {  // camelCase
+        type: 'string',
+        title: 'Published At',
+        format: 'date-time',
+      },
+    },
+  },
+  access: {
+    read: () => true,
+    create: ({ user }) => !!user,
+    update: ({ user }) => !!user,
+    delete: ({ user }) => user?.role === 'admin',
+  },
+}
+```
+
+</CodeGroup>
+
+### Route Handlers
+
+<CodeGroup title="Route Handler Pattern">
+
+```typescript
+import { Hono } from 'hono'
+import type { Context } from 'hono'
+
+const app = new Hono()
+
+app.get('/users/:id', async (c: Context) => {
+  const { id } = c.req.param()
+
+  try {
+    const user = await userService.getById(id)
+
+    if (!user) {
+      return c.json({ error: 'User not found' }, 404)
+    }
+
+    return c.json({ data: user })  // camelCase in response
+  } catch (error) {
+    logger.error('Failed to get user', { id, error })
+    return c.json({ error: 'Internal server error' }, 500)
+  }
+})
+```
+
+</CodeGroup>
+
+### Middleware
+
+<CodeGroup title="Middleware Pattern">
+
+```typescript
+import type { MiddlewareHandler } from 'hono'
+
+export const authMiddleware: MiddlewareHandler = async (c, next) => {
+  const token = c.req.header('Authorization')?.replace('Bearer ', '')
+
+  if (!token) {
+    return c.json({ error: 'Unauthorized' }, 401)
+  }
+
+  try {
+    const user = await verifyToken(token)
+    c.set('user', user)
+    await next()
+  } catch (error) {
+    return c.json({ error: 'Invalid token' }, 401)
+  }
+}
+```
+
+</CodeGroup>
+
+---
+
+## Testing Standards
+
+### Test File Location
+
+Place test files next to the code they test:
+
+```
+src/
+  services/
+    user-service.ts
+    user-service.test.ts
+  routes/
+    api.ts
+    api.test.ts
+```
+
+### Test Naming
+
+Use descriptive test names:
+
+```typescript
+describe('UserService', () => {
+  describe('getById', () => {
+    it('returns user when found', async () => {
+      // ...
+    })
+
+    it('returns null when user does not exist', async () => {
+      // ...
+    })
+
+    it('throws error when database connection fails', async () => {
+      // ...
+    })
+  })
+})
+```
+
+---
+
+## Formatting and Linting
+
+### Automatic Formatting
+
+Prettier runs automatically on commit with this configuration:
+
+```json
+{
+  "semi": false,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "es5"
+}
+```
+
+### Before Committing
+
+Run these commands before submitting a PR:
+
+```bash
+npm run lint      # ESLint rules must pass
+npm run format    # Format with Prettier
+npm test          # All tests must pass
+```
+
+---
+
+## Questions?
+
+If you have questions about these standards:
+
+- Check [existing issues](https://github.com/lane711/sonicjs/issues)
+- Ask in [GitHub Discussions](https://github.com/lane711/sonicjs/discussions)
+- Join our [Discord](https://discord.gg/8bMy6bv3sZ)

--- a/www/src/components/Navigation.tsx
+++ b/www/src/components/Navigation.tsx
@@ -282,6 +282,7 @@ export const navigation: Array<NavGroup> = [
       { title: 'Changelog', href: '/changelog' },
       { title: 'Community', href: '/community' },
       { title: 'Contributing', href: '/contributing' },
+      { title: 'Coding Standards', href: '/coding-standards' },
       { title: 'Telemetry', href: '/telemetry' },
     ],
   },


### PR DESCRIPTION
## Summary

- Add `CODING_STANDARDS.md` with comprehensive naming conventions and code style guidelines
- Add coding standards page to www documentation site at `/coding-standards`
- Update `CONTRIBUTING.md` to reference new coding standards guide
- Add `predev` script to `www/package.json` to auto-generate `allSections.json` before dev server starts

## Key Standards Established

| Element | Convention | Example |
|---------|------------|---------|
| Collection names | snake_case | `blog_posts` |
| Schema field names | camelCase | `featuredImage` |
| Database columns | snake_case | `featured_image` |
| API responses | camelCase | `createdAt` |
| TypeScript variables | camelCase | `userData` |
| Classes/Types | PascalCase | `UserService` |
| Constants | SCREAMING_SNAKE_CASE | `MAX_RETRIES` |
| File names | kebab-case | `user-service.ts` |

## Test plan

- [x] Verify CODING_STANDARDS.md is comprehensive and accurate
- [x] Verify www page renders correctly at `/coding-standards`
- [x] Verify Navigation.tsx includes new link in Resources section
- [x] Verify CONTRIBUTING.md links to new guide
- [x] Verify `npm run dev` in www folder runs without errors (predev generates allSections.json)

Closes #429

🤖 Generated with [Claude Code](https://claude.com/claude-code)