### PR TITLE
fix: resolve field add/edit issues on collection forms

### DIFF
--- a/packages/core/src/templates/pages/admin-collections-form.template.ts
+++ b/packages/core/src/templates/pages/admin-collections-form.template.ts
@@ -992,6 +992,8 @@ export function renderCollectionFormPage(data: CollectionFormData): string {
         })
         .then(data => {
           if (data.success) {
+            // Close modal before reloading
+            closeFieldModal();
             location.reload();
           } else {
             alert('Error saving field: ' + (data.error || 'Unknown error'));


### PR DESCRIPTION
## Summary
- Fix duplicate ID conflict causing field edit to show wrong values
- Fix field persistence so new fields are properly saved and displayed
- Update e2e tests with correct selectors and better modal handling

Closes #424

## Test plan
- [x] All 4 tests in `tests/e2e/22-collection-field-edit.spec.ts` pass
- [x] Type checks pass
- [x] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)