### PR TITLE
feat: add release announcement agent and fix www deployment

### DIFF
--- a/.claude/commands/release-announcement.md
+++ b/.claude/commands/release-announcement.md
@@ -1,0 +1,281 @@
+# Release Announcement Agent
+
+You are a specialized agent that creates compelling release announcements for SonicJS across multiple platforms. Your primary responsibilities are:
+
+1. **Generate release content** - Create engaging, platform-specific announcement content
+2. **Post to Discord** - Send rich embeds to the SonicJS Discord community
+3. **Post to Twitter/X** - Create announcement threads with appropriate hashtags
+4. **Update website** - Prepare changelog and home page updates
+
+## Background
+
+SonicJS is an open-source headless CMS built for Cloudflare Workers. Key selling points:
+- **6x faster** than traditional Node.js/Express
+- **Global edge deployment** on Cloudflare Workers
+- **SQLite/D1** for data storage
+- **Open source** and developer-friendly
+- **Admin UI** out of the box
+
+Target audience: JavaScript/TypeScript developers, Cloudflare users, CMS enthusiasts, JAMstack developers.
+
+## Content Generation Guidelines
+
+### Discord Content
+- Title: Use emoji + version announcement format
+- Description: 1-2 sentences explaining the release significance
+- Highlights: 3-5 bullet points of key changes (extract from release notes)
+- Tone: Friendly, community-focused, technical
+
+### Twitter/X Content
+- Main tweet: Under 280 chars, catchy, includes version
+- Hashtags: #SonicJS #CloudflareWorkers #HeadlessCMS #OpenSource
+- Thread: Break down key features, include call-to-action
+- Include GitHub stars request in final tweet
+
+### Website Content
+- Home changelog: Brief one-line summary
+- Full changelog: Structured markdown with all changes
+
+## Workflow 1: Generate Release Content
+
+When asked to generate release content, follow these steps:
+
+### Step 1: Get Release Information
+
+First, read the current version and recent changes:
+
+```bash
+# Get current version
+grep '"version"' packages/core/package.json
+
+# Check for release notes file or recent commits
+git log --oneline -10
+```
+
+### Step 2: Analyze Changes
+
+Review the release notes or commit history to identify:
+- New features
+- Bug fixes
+- Breaking changes
+- Performance improvements
+- Documentation updates
+
+### Step 3: Generate Content JSON
+
+Create a `.release-content.json` file in the project root with this structure:
+
+```json
+{
+  "discord": {
+    "title": "🚀 SonicJS v{VERSION} Released!",
+    "description": "Brief exciting description of what's new",
+    "highlights": [
+      "Key feature or fix 1",
+      "Key feature or fix 2",
+      "Key feature or fix 3"
+    ]
+  },
+  "twitter": {
+    "text": "🚀 SonicJS v{VERSION} is now available! Brief exciting hook under 280 chars.",
+    "hashtags": ["SonicJS", "CloudflareWorkers", "HeadlessCMS", "OpenSource"],
+    "thread": [
+      "✨ What's new:\n\n1. Feature one\n2. Feature two\n3. Feature three",
+      "📦 Get started:\nnpx create-sonicjs@latest my-app\n\nSonicJS is 6x faster than Node/Express and deploys globally on Cloudflare Workers.",
+      "⭐ Love SonicJS? Star us on GitHub!\n\nhttps://github.com/lane711/sonicjs\n\nYour support helps us keep improving!"
+    ]
+  },
+  "www": {
+    "homeChangelog": "v{VERSION} - Brief summary",
+    "fullChangelog": "## v{VERSION} - {DATE}\n\n### New Features\n- Feature 1\n\n### Bug Fixes\n- Fix 1"
+  }
+}
+```
+
+## Workflow 2: Post Release Announcement
+
+When asked to announce a release:
+
+### Step 1: Verify Content Exists
+
+Check if `.release-content.json` exists. If not, generate it first using Workflow 1.
+
+### Step 2: Dry Run (Recommended)
+
+```bash
+npm run release:announce:dry
+```
+
+Review the output to ensure content looks correct.
+
+### Step 3: Post Announcement
+
+```bash
+npm run release:announce
+```
+
+This will:
+1. Post to Discord (if DISCORD_WEBHOOK_URL is set)
+2. Post to Twitter/X (if Twitter credentials are set)
+3. Update WWW folder locally
+
+### Step 4: Verify Posts
+
+After posting, verify:
+- Discord message appears in the announcements channel
+- Twitter thread is posted correctly
+- Website changes are ready for commit
+
+## Workflow 3: Post to Individual Platforms
+
+### Discord Only
+```bash
+npm run release:announce -- --skip-twitter --skip-www
+```
+
+### Twitter Only
+```bash
+npm run release:announce -- --skip-discord --skip-www
+```
+
+### Website Only
+```bash
+npm run release:announce -- --skip-discord --skip-twitter
+```
+
+## Workflow 4: Manual Discord Notification
+
+For quick Discord notifications without full release:
+
+```bash
+npm run notify:discord
+```
+
+Or send a custom message:
+```bash
+node scripts/notify-discord.js "Custom message here"
+```
+
+## Content Examples
+
+### Example: Feature Release
+
+```json
+{
+  "discord": {
+    "title": "🚀 SonicJS v2.4.0 Released!",
+    "description": "This release brings powerful new features including real-time subscriptions and improved admin UI performance.",
+    "highlights": [
+      "Real-time GraphQL subscriptions support",
+      "50% faster admin dashboard loading",
+      "New bulk operations API",
+      "Improved TypeScript types"
+    ]
+  },
+  "twitter": {
+    "text": "🚀 SonicJS v2.4.0 is here! Real-time subscriptions, faster admin UI, and more. The edge-native headless CMS keeps getting better!",
+    "hashtags": ["SonicJS", "CloudflareWorkers", "HeadlessCMS", "Realtime"],
+    "thread": [
+      "✨ What's new in v2.4.0:\n\n1. 🔄 Real-time GraphQL subscriptions\n2. ⚡ 50% faster admin dashboard\n3. 📦 Bulk operations API\n4. 🔷 Better TypeScript support",
+      "Real-time subscriptions let you build live dashboards, collaborative apps, and instant notifications - all running on the edge!\n\nPowered by Cloudflare Durable Objects.",
+      "📦 Get started today:\nnpx create-sonicjs@latest my-app\n\nOr upgrade:\nnpm install @sonicjs-cms/core@latest",
+      "⭐ If SonicJS is useful for your projects, please star us on GitHub!\n\nhttps://github.com/lane711/sonicjs\n\nYour support helps us build more awesome features!"
+    ]
+  }
+}
+```
+
+### Example: Bug Fix Release
+
+```json
+{
+  "discord": {
+    "title": "🔧 SonicJS v2.3.13 - Bug Fixes",
+    "description": "A maintenance release with important bug fixes and stability improvements.",
+    "highlights": [
+      "Fixed collection form field editing",
+      "Resolved database migration edge case",
+      "Improved error handling in API routes"
+    ]
+  },
+  "twitter": {
+    "text": "🔧 SonicJS v2.3.13 released with bug fixes and stability improvements. Thanks to our community for reporting issues!",
+    "hashtags": ["SonicJS", "OpenSource", "BugFix"],
+    "thread": [
+      "🔧 Fixes in v2.3.13:\n\n• Collection form field editing\n• Database migration edge cases\n• API error handling improvements",
+      "📦 Upgrade now:\nnpm install @sonicjs-cms/core@2.3.13\n\nOr start fresh:\nnpx create-sonicjs@latest my-app"
+    ]
+  }
+}
+```
+
+## Environment Variables
+
+The announcement system requires these environment variables (set in `.env`):
+
+```bash
+# Discord
+DISCORD_WEBHOOK_URL=https://discord.com/api/webhooks/...
+
+# Twitter/X OAuth 1.0a
+TWITTER_API_KEY=your_api_key
+TWITTER_API_SECRET=your_api_secret
+TWITTER_ACCESS_TOKEN=your_access_token
+TWITTER_ACCESS_SECRET=your_access_secret
+```
+
+## Usage Examples
+
+```
+/release-announcement generate      # Generate content for current version
+/release-announcement post          # Post announcement to all platforms
+/release-announcement dry-run       # Preview announcement without posting
+/release-announcement discord       # Post to Discord only
+/release-announcement twitter       # Post to Twitter only
+```
+
+## Error Handling
+
+### Discord Errors
+- **Webhook not found**: Verify DISCORD_WEBHOOK_URL is correct
+- **Rate limited**: Wait and retry, Discord has rate limits
+- **Invalid embed**: Check content length and formatting
+
+### Twitter Errors
+- **401 Unauthorized**: Verify all 4 Twitter credentials are correct
+- **403 Forbidden**: App may lack write permissions
+- **Tweet too long**: Ensure all tweets are under 280 characters
+- **Rate limited**: Wait 15 minutes and retry
+
+### Content Errors
+- **Missing content**: Generate content first with Workflow 1
+- **Invalid JSON**: Check `.release-content.json` syntax
+- **Empty highlights**: Add at least one highlight
+
+## Important Notes
+
+1. **Always preview first**: Use `--dry-run` before posting to verify content
+2. **Check character limits**: Twitter has strict 280 char limit
+3. **Credentials in .env**: Never commit credentials to git
+4. **Content quality**: Take time to write compelling announcements
+5. **Community engagement**: End Twitter threads with GitHub star request
+6. **Timing**: Post announcements during US/EU business hours for visibility
+
+## Post-Announcement Checklist
+
+After posting announcements, verify:
+
+1. **Discord**
+   - Message appears in announcements channel
+   - Embed renders correctly with all fields
+   - Links are clickable
+
+2. **Twitter/X**
+   - Thread is properly connected
+   - Hashtags are visible
+   - Links expand correctly
+
+3. **Website** (if applicable)
+   - Commit and push WWW changes
+   - Verify changelog page updated
+   - Check home page recent updates section

--- a/www/next.config.mjs
+++ b/www/next.config.mjs
@@ -1,9 +1,13 @@
 import nextMDX from '@next/mdx'
+import path from 'path'
+import { fileURLToPath } from 'url'
 
 import { recmaPlugins } from './src/mdx/recma.mjs'
 import { rehypePlugins } from './src/mdx/rehype.mjs'
 import { remarkPlugins } from './src/mdx/remark.mjs'
 import withSearch from './src/mdx/search.mjs'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
 
 const withMDX = nextMDX({
   options: {
@@ -16,6 +20,7 @@ const withMDX = nextMDX({
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'mdx'],
+  outputFileTracingRoot: path.join(__dirname, '..'),
   outputFileTracingIncludes: {
     '/**/*': ['./src/app/**/*.mdx'],
   },

--- a/www/src/app/changelog/page.mdx
+++ b/www/src/app/changelog/page.mdx
@@ -93,6 +93,35 @@ export const sections = [
 
 
 
+
+{/* Version 2.3.13 */}
+<div className="relative pl-8 pb-8 border-l-2 border-emerald-200 dark:border-emerald-800">
+  <div className="absolute -left-3 top-0 w-6 h-6 rounded-full bg-emerald-500 border-4 border-white dark:border-gray-900 shadow-lg"></div>
+
+  <div className="bg-gradient-to-br from-emerald-50 to-teal-50 dark:from-emerald-900/20 dark:to-teal-900/20 rounded-xl p-6 border border-emerald-200 dark:border-emerald-800 shadow-md hover:shadow-xl transition-shadow">
+    <div className="flex items-center gap-3 mb-4">
+      <span className="px-3 py-1 bg-emerald-500 text-white text-sm font-bold rounded-lg">v2.3.13</span>
+      <span className="text-sm text-gray-600 dark:text-gray-400">December 18, 2025</span>
+      <span className="px-2 py-1 bg-gradient-to-r from-orange-100 to-red-100 dark:from-orange-900/30 dark:to-red-900/30 border border-orange-300 dark:border-orange-700 text-orange-800 dark:text-orange-300 text-xs font-bold rounded uppercase">Latest</span>
+    </div>
+
+    <div className="space-y-3">
+      <div>
+        <h4 className="text-sm font-bold text-emerald-800 dark:text-emerald-300 mb-2 flex items-center gap-2">
+          <span>✨</span> Highlights
+        </h4>
+        <ul className="space-y-1.5 ml-6 text-sm text-gray-700 dark:text-gray-300">
+          <li className="flex items-start gap-2"><span className="text-emerald-500">▸</span>New Release Engineer agent for automated npm publishing</li>
+          <li className="flex items-start gap-2"><span className="text-emerald-500">▸</span>Fixed field add/edit issues on collection forms</li>
+          <li className="flex items-start gap-2"><span className="text-emerald-500">▸</span>EasyMDE markdown editor plugin with database migration</li>
+          <li className="flex items-start gap-2"><span className="text-emerald-500">▸</span>ESLint integration with naming convention rules</li>
+          <li className="flex items-start gap-2"><span className="text-emerald-500">▸</span>Fullstack developer agent with testing workflow</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
 {/* Version 2.3.12 */}
 <div className="relative pl-8 pb-8 border-l-2 border-emerald-200 dark:border-emerald-800">
   <div className="absolute -left-3 top-0 w-6 h-6 rounded-full bg-emerald-500 border-4 border-white dark:border-gray-900 shadow-lg"></div>
@@ -101,7 +130,7 @@ export const sections = [
     <div className="flex items-center gap-3 mb-4">
       <span className="px-3 py-1 bg-emerald-500 text-white text-sm font-bold rounded-lg">v2.3.12</span>
       <span className="text-sm text-gray-600 dark:text-gray-400">December 10, 2025</span>
-      <span className="px-2 py-1 bg-gradient-to-r from-orange-100 to-red-100 dark:from-orange-900/30 dark:to-red-900/30 border border-orange-300 dark:border-orange-700 text-orange-800 dark:text-orange-300 text-xs font-bold rounded uppercase">Latest</span>
+      
     </div>
 
     <div className="space-y-3">


### PR DESCRIPTION
## Summary

- Add `release-announcement.md` Claude command for generating and posting release announcements to Discord and Twitter/X
- Fix www deployment by adding `outputFileTracingRoot` to `next.config.mjs` to prevent Next.js from using wrong workspace root when multiple lockfiles exist
- Update changelog page with v2.3.13 release notes

## Changes

### New Release Announcement Agent
The agent can:
- Generate platform-specific content for Discord embeds and Twitter threads
- Post announcements via the existing `npm run release:announce` infrastructure
- Preview announcements with dry-run mode
- Post to individual platforms selectively

### WWW Deployment Fix
Fixed the `npm run deploy:www` command which was failing with "Module not found" errors. The issue was Next.js detecting a `package-lock.json` in the user's home directory and using that as the workspace root. Added `outputFileTracingRoot` to explicitly set the correct monorepo root.

## Test plan

- [x] Tested release announcement posting to Discord and Twitter
- [x] Verified `npm run deploy --workspace=www` completes successfully
- [x] Changelog page renders correctly with new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)