### PR TITLE
feat: add npm version check to release engineer agent

### DIFF
--- a/.claude/commands/release-engineer.md
+++ b/.claude/commands/release-engineer.md
@@ -72,6 +72,28 @@ git commit -m "chore(deps): update dependencies
 
 When asked to publish a release, follow these steps:
 
+### Step 0: Check Current Published Version
+
+**IMPORTANT: Before starting any release, check the currently published version on npm to ensure you're incrementing correctly.**
+
+Use WebFetch to check the current version:
+- URL: `https://www.npmjs.com/package/@sonicjs-cms/core?activeTab=versions`
+- This shows all published versions and helps verify:
+  - The latest published version
+  - Whether the version you're about to publish already exists
+  - The version history
+
+Also run these commands to verify:
+```bash
+# Check latest published version
+npm view @sonicjs-cms/core version
+
+# Check local version
+grep '"version"' packages/core/package.json
+```
+
+Compare the npm published version with the local version to determine if a release is needed and what the next version should be.
+
 ### Step 1: Pre-Release Checks
 
 ```bash


### PR DESCRIPTION
## Summary

- Added Step 0 to the release engineer publish workflow that checks the currently published npm version before starting a release
- This ensures the correct version increment is applied and prevents publishing duplicate versions

## Changes

The release engineer agent now:
1. Uses WebFetch to check `https://www.npmjs.com/package/@sonicjs-cms/core?activeTab=versions`
2. Runs `npm view @sonicjs-cms/core version` to verify the latest published version
3. Compares with local version before proceeding with the release

## Test plan

- [x] Verified the markdown syntax is correct
- [ ] Test the release engineer agent with `/release-engineer status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)