### PR TITLE
feat: add social media marketing agent

### DIFF
--- a/.claude/commands/social-post.md
+++ b/.claude/commands/social-post.md
@@ -1,0 +1,75 @@
+# Social Media Marketing Agent
+
+You are a social media marketing agent for SonicJS. Your job is to help post announcements to Discord and Twitter/X.
+
+## Available Scripts
+
+You have access to these scripts in `scripts/social/`:
+
+1. **post-discord.js** - Post to Discord
+   ```bash
+   node scripts/social/post-discord.js "Your message here"
+   node scripts/social/post-discord.js --title "Title" --message "Message"
+   node scripts/social/post-discord.js --dry-run "Test message"
+   ```
+
+2. **post-twitter.js** - Post to Twitter/X
+   ```bash
+   node scripts/social/post-twitter.js "Your tweet here"
+   node scripts/social/post-twitter.js --text "Tweet" --hashtags "SonicJS,CMS"
+   node scripts/social/post-twitter.js --url "https://sonicjs.com" "Your tweet"
+   node scripts/social/post-twitter.js --dry-run "Test tweet"
+   ```
+
+3. **post-both.js** - Post to both platforms
+   ```bash
+   node scripts/social/post-both.js "Your announcement"
+   node scripts/social/post-both.js --title "Title" --message "Message"
+   node scripts/social/post-both.js --discord-only "Discord only"
+   node scripts/social/post-both.js --twitter-only "Twitter only"
+   node scripts/social/post-both.js --dry-run "Test message"
+   ```
+
+## User Request
+$ARGUMENTS
+
+## Instructions
+
+1. Parse the user's request to understand:
+   - What message they want to post
+   - Which platform(s) to post to (discord, twitter, or both)
+
+2. If the platform is unclear, ask which platform they want to post to.
+
+3. If the message is unclear, ask for the message content.
+
+4. ALWAYS do a dry run first to show the user what will be posted.
+
+5. Ask for confirmation before actually posting.
+
+6. Execute the appropriate script with the message.
+
+7. Report the result back to the user.
+
+## Twitter Character Limits
+- Keep tweets under 280 characters
+- Hashtags are added automatically: #SonicJS #CloudflareCMS #OpenSource #Webdev
+- You can customize hashtags with --hashtags "Tag1,Tag2"
+- Use --no-hashtags to skip adding hashtags
+
+## Examples
+
+**Discord only:**
+```bash
+node scripts/social/post-discord.js --title "New Release" --message "We just released v2.4.0!"
+```
+
+**Twitter only:**
+```bash
+node scripts/social/post-twitter.js "Check out SonicJS v2.4.0 - the fastest CMS on Cloudflare!"
+```
+
+**Both platforms:**
+```bash
+node scripts/social/post-both.js "SonicJS v2.4.0 is here with amazing new features!"
+```

--- a/docs/ai/social-media-agent.md
+++ b/docs/ai/social-media-agent.md
@@ -1,0 +1,113 @@
+# Social Media Marketing Agent
+
+A Claude Code sub-agent for posting to Discord and Twitter/X on command.
+
+## Quick Start
+
+Use the `/social-post` slash command in Claude Code:
+
+```
+/social-post Post to discord: We just released version 2.4.0!
+/social-post Tweet about our new admin dashboard
+/social-post Announce on both platforms that we hit 1000 stars!
+```
+
+## Available Scripts
+
+### Post to Discord
+
+```bash
+# Simple message
+npm run social:discord "Your message here"
+
+# With title
+npm run social:discord -- --title "New Release" --message "We released v2.4!"
+
+# Dry run (preview without posting)
+npm run social:discord -- --dry-run "Test message"
+```
+
+### Post to Twitter/X
+
+```bash
+# Simple tweet
+npm run social:twitter "Your tweet here"
+
+# With custom hashtags
+npm run social:twitter -- --hashtags "SonicJS,CMS,CloudFlare" "Your tweet"
+
+# With a link
+npm run social:twitter -- --url "https://sonicjs.com" "Check out SonicJS!"
+
+# Dry run
+npm run social:twitter -- --dry-run "Test tweet"
+```
+
+### Post to Both Platforms
+
+```bash
+# Same message to both
+npm run social:post "Your announcement here"
+
+# With options
+npm run social:post -- --title "Big News" --message "We released v2.4!"
+
+# Discord only
+npm run social:post -- --discord-only "Discord only message"
+
+# Twitter only
+npm run social:post -- --twitter-only "Twitter only message"
+
+# Dry run
+npm run social:post -- --dry-run "Test message"
+```
+
+## Environment Variables
+
+### Discord
+- `DISCORD_WEBHOOK_URL` - Optional. Uses the default SonicJS webhook if not set.
+
+### Twitter/X
+All four of these are required to post to Twitter:
+- `TWITTER_API_KEY` - Twitter API Key (Consumer Key)
+- `TWITTER_API_SECRET` - Twitter API Secret (Consumer Secret)
+- `TWITTER_ACCESS_TOKEN` - User Access Token
+- `TWITTER_ACCESS_SECRET` - User Access Token Secret
+
+## Claude Code Slash Command
+
+The `/social-post` command is an interactive agent that:
+
+1. Parses your request to understand the message and platform
+2. Shows a preview (dry run) of what will be posted
+3. Asks for confirmation
+4. Posts to the specified platform(s)
+5. Reports the result
+
+### Examples
+
+```
+/social-post discord: Just released v2.4.0 with new admin features!
+/social-post tweet: Check out the fastest CMS on Cloudflare - SonicJS v2.4!
+/social-post both: SonicJS v2.4.0 is here! New admin UI, better performance.
+```
+
+## Twitter Character Limits
+
+- Maximum tweet length: 280 characters
+- Default hashtags are added: #SonicJS #CloudflareCMS #OpenSource #Webdev
+- Use `--hashtags "Tag1,Tag2"` to customize
+- Use `--no-hashtags` to skip hashtags
+
+## Files
+
+- `.claude/commands/social-post.md` - Claude Code slash command
+- `scripts/social/post-discord.js` - Discord posting script
+- `scripts/social/post-twitter.js` - Twitter posting script
+- `scripts/social/post-both.js` - Cross-platform posting script
+
+## Security Notes
+
+- The Discord webhook URL is stored in `docs/ai/discord-release-notifications.md`
+- Twitter credentials should be set as environment variables, not committed
+- Always do a dry run first to preview before posting

--- a/package.json
+++ b/package.json
@@ -40,6 +40,9 @@
     "release:announce": "node scripts/release/index.js",
     "release:announce:dry": "node scripts/release/index.js --dry-run",
     "notify:discord": "node scripts/notify-discord.js",
+    "social:discord": "node scripts/social/post-discord.js",
+    "social:twitter": "node scripts/social/post-twitter.js",
+    "social:post": "node scripts/social/post-both.js",
     "db:reset": "npm run setup:db --workspace=my-sonicjs-app",
     "workspace": "npm install && npm run db:reset",
     "kill": "pkill workerd && npm run dev --workspace=my-sonicjs-app"

--- a/scripts/social/post-both.js
+++ b/scripts/social/post-both.js
@@ -1,0 +1,168 @@
+#!/usr/bin/env node
+
+/**
+ * Cross-Platform Social Post Script
+ *
+ * Posts the same message to both Discord and Twitter/X.
+ *
+ * Usage:
+ *   node scripts/social/post-both.js "Your announcement here"
+ *   node scripts/social/post-both.js --title "Title" --message "Message"
+ *   node scripts/social/post-both.js --dry-run "Test message"
+ *   node scripts/social/post-both.js --discord-only "Discord only message"
+ *   node scripts/social/post-both.js --twitter-only "Twitter only message"
+ *
+ * Environment:
+ *   DISCORD_WEBHOOK_URL - Discord webhook URL (optional)
+ *   TWITTER_API_KEY, TWITTER_API_SECRET, etc. - Twitter credentials
+ */
+
+import { spawn } from 'child_process'
+import { fileURLToPath } from 'url'
+import path from 'path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+/**
+ * Parse command line arguments
+ */
+function parseArgs() {
+  const args = process.argv.slice(2)
+  const options = {
+    dryRun: false,
+    title: null,
+    message: null,
+    discordOnly: false,
+    twitterOnly: false,
+    hashtags: null,
+    url: null
+  }
+
+  let i = 0
+  while (i < args.length) {
+    const arg = args[i]
+
+    if (arg === '--dry-run') {
+      options.dryRun = true
+    } else if (arg === '--title' && args[i + 1]) {
+      options.title = args[++i]
+    } else if (arg === '--message' && args[i + 1]) {
+      options.message = args[++i]
+    } else if (arg === '--discord-only') {
+      options.discordOnly = true
+    } else if (arg === '--twitter-only') {
+      options.twitterOnly = true
+    } else if (arg === '--hashtags' && args[i + 1]) {
+      options.hashtags = args[++i]
+    } else if (arg === '--url' && args[i + 1]) {
+      options.url = args[++i]
+    } else if (!arg.startsWith('--')) {
+      // Positional argument is the message
+      options.message = arg
+    }
+    i++
+  }
+
+  return options
+}
+
+/**
+ * Run a script with arguments
+ */
+function runScript(scriptPath, args) {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('node', [scriptPath, ...args], {
+      stdio: 'inherit',
+      env: process.env
+    })
+
+    proc.on('close', code => {
+      if (code === 0) {
+        resolve({ success: true })
+      } else {
+        resolve({ error: true, code })
+      }
+    })
+
+    proc.on('error', err => {
+      reject(err)
+    })
+  })
+}
+
+/**
+ * Main function
+ */
+async function main() {
+  const options = parseArgs()
+
+  if (!options.message) {
+    console.error('❌ Error: No message provided')
+    console.error('Usage: node scripts/social/post-both.js "Your message here"')
+    process.exit(1)
+  }
+
+  console.log('📢 Social Media Post\n')
+
+  if (options.dryRun) {
+    console.log('🔵 DRY RUN MODE - No actual posts will be made\n')
+  }
+
+  const results = {
+    discord: null,
+    twitter: null
+  }
+
+  // Post to Discord
+  if (!options.twitterOnly) {
+    console.log('💬 Discord:')
+    const discordArgs = []
+    if (options.dryRun) discordArgs.push('--dry-run')
+    if (options.title) discordArgs.push('--title', options.title)
+    discordArgs.push('--message', options.message)
+
+    results.discord = await runScript(path.join(__dirname, 'post-discord.js'), discordArgs)
+    console.log('')
+  }
+
+  // Post to Twitter
+  if (!options.discordOnly) {
+    console.log('🐦 Twitter:')
+    const twitterArgs = []
+    if (options.dryRun) twitterArgs.push('--dry-run')
+    if (options.hashtags) twitterArgs.push('--hashtags', options.hashtags)
+    if (options.url) twitterArgs.push('--url', options.url)
+    twitterArgs.push('--text', options.message)
+
+    results.twitter = await runScript(path.join(__dirname, 'post-twitter.js'), twitterArgs)
+    console.log('')
+  }
+
+  // Summary
+  console.log('📊 Summary')
+  console.log('─'.repeat(40))
+
+  if (!options.twitterOnly) {
+    const discordStatus = results.discord?.success ? '✅ Posted' : results.discord?.error ? '❌ Failed' : '⏭️ Skipped'
+    console.log(`Discord: ${discordStatus}`)
+  }
+
+  if (!options.discordOnly) {
+    const twitterStatus = results.twitter?.success ? '✅ Posted' : results.twitter?.error ? '❌ Failed' : '⏭️ Skipped'
+    console.log(`Twitter: ${twitterStatus}`)
+  }
+
+  // Check for errors
+  const hasError = results.discord?.error || results.twitter?.error
+  if (hasError) {
+    process.exit(1)
+  }
+
+  console.log('\n✨ Done!')
+}
+
+main().catch(err => {
+  console.error('❌ Fatal error:', err)
+  process.exit(1)
+})

--- a/scripts/social/post-discord.js
+++ b/scripts/social/post-discord.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+
+/**
+ * Discord Post Script
+ *
+ * Posts a custom message to the SonicJS Discord server.
+ *
+ * Usage:
+ *   node scripts/social/post-discord.js "Your message here"
+ *   node scripts/social/post-discord.js --title "Title" --message "Message"
+ *   node scripts/social/post-discord.js --dry-run "Test message"
+ *
+ * Environment:
+ *   DISCORD_WEBHOOK_URL - Discord webhook URL (optional, uses default if not set)
+ */
+
+const DEFAULT_WEBHOOK = 'https://discord.com/api/webhooks/1443339433318285442/lnxdw64Wze72PjY8EhxPYF6bLGjqBwOi8EqwOnZxUFPo82E37o6myjQ1aO-8dzvsaStN'
+
+/**
+ * Parse command line arguments
+ */
+function parseArgs() {
+  const args = process.argv.slice(2)
+  const options = {
+    dryRun: false,
+    title: null,
+    message: null,
+    color: 0x5865f2 // Discord blurple
+  }
+
+  let i = 0
+  while (i < args.length) {
+    const arg = args[i]
+
+    if (arg === '--dry-run') {
+      options.dryRun = true
+    } else if (arg === '--title' && args[i + 1]) {
+      options.title = args[++i]
+    } else if (arg === '--message' && args[i + 1]) {
+      options.message = args[++i]
+    } else if (arg === '--color' && args[i + 1]) {
+      options.color = parseInt(args[++i], 16)
+    } else if (!arg.startsWith('--')) {
+      // Positional argument is the message
+      options.message = arg
+    }
+    i++
+  }
+
+  return options
+}
+
+/**
+ * Post message to Discord
+ */
+async function postToDiscord(options) {
+  const webhookUrl = process.env.DISCORD_WEBHOOK_URL || DEFAULT_WEBHOOK
+
+  if (!options.message) {
+    console.error('❌ Error: No message provided')
+    console.error('Usage: node scripts/social/post-discord.js "Your message here"')
+    process.exit(1)
+  }
+
+  const embed = {
+    embeds: [{
+      title: options.title || '📢 SonicJS Announcement',
+      description: options.message,
+      color: options.color,
+      timestamp: new Date().toISOString(),
+      footer: { text: 'SonicJS CMS' }
+    }]
+  }
+
+  if (options.dryRun) {
+    console.log('🔵 [DRY RUN] Would post to Discord:')
+    console.log('---')
+    console.log(`Title: ${embed.embeds[0].title}`)
+    console.log(`Message: ${embed.embeds[0].description}`)
+    console.log('---')
+    return { dryRun: true }
+  }
+
+  try {
+    const response = await fetch(webhookUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(embed)
+    })
+
+    if (response.ok) {
+      console.log('✅ Posted to Discord successfully!')
+      return { success: true }
+    } else {
+      const errorText = await response.text()
+      console.error(`❌ Failed to post: ${response.status} - ${errorText}`)
+      return { error: true, status: response.status, message: errorText }
+    }
+  } catch (error) {
+    console.error('❌ Error:', error.message)
+    return { error: true, message: error.message }
+  }
+}
+
+// Run if called directly
+const options = parseArgs()
+postToDiscord(options)

--- a/scripts/social/post-twitter.js
+++ b/scripts/social/post-twitter.js
@@ -1,0 +1,213 @@
+#!/usr/bin/env node
+
+/**
+ * Twitter/X Post Script
+ *
+ * Posts a custom tweet to the SonicJS Twitter account.
+ *
+ * Usage:
+ *   node scripts/social/post-twitter.js "Your tweet here"
+ *   node scripts/social/post-twitter.js --text "Tweet" --hashtags "SonicJS,CMS"
+ *   node scripts/social/post-twitter.js --dry-run "Test tweet"
+ *
+ * Environment:
+ *   TWITTER_API_KEY - Twitter API Key (Consumer Key)
+ *   TWITTER_API_SECRET - Twitter API Secret (Consumer Secret)
+ *   TWITTER_ACCESS_TOKEN - User Access Token
+ *   TWITTER_ACCESS_SECRET - User Access Token Secret
+ */
+
+import crypto from 'crypto'
+
+const TWITTER_API_URL = 'https://api.twitter.com/2/tweets'
+const DEFAULT_HASHTAGS = ['SonicJS', 'CloudflareCMS', 'OpenSource', 'Webdev']
+
+/**
+ * Parse command line arguments
+ */
+function parseArgs() {
+  const args = process.argv.slice(2)
+  const options = {
+    dryRun: false,
+    text: null,
+    hashtags: DEFAULT_HASHTAGS,
+    url: null
+  }
+
+  let i = 0
+  while (i < args.length) {
+    const arg = args[i]
+
+    if (arg === '--dry-run') {
+      options.dryRun = true
+    } else if (arg === '--text' && args[i + 1]) {
+      options.text = args[++i]
+    } else if (arg === '--hashtags' && args[i + 1]) {
+      options.hashtags = args[++i].split(',').map(h => h.trim())
+    } else if (arg === '--url' && args[i + 1]) {
+      options.url = args[++i]
+    } else if (arg === '--no-hashtags') {
+      options.hashtags = []
+    } else if (!arg.startsWith('--')) {
+      // Positional argument is the text
+      options.text = arg
+    }
+    i++
+  }
+
+  return options
+}
+
+/**
+ * Get Twitter credentials from environment
+ */
+function getCredentials() {
+  const apiKey = process.env.TWITTER_API_KEY
+  const apiSecret = process.env.TWITTER_API_SECRET
+  const accessToken = process.env.TWITTER_ACCESS_TOKEN
+  const accessSecret = process.env.TWITTER_ACCESS_SECRET
+
+  if (!apiKey || !apiSecret || !accessToken || !accessSecret) {
+    return null
+  }
+
+  return { apiKey, apiSecret, accessToken, accessSecret }
+}
+
+/**
+ * Generate OAuth 1.0a signature
+ */
+function generateOAuthSignature(method, url, params, credentials) {
+  const signatureBaseString = [
+    method.toUpperCase(),
+    encodeURIComponent(url),
+    encodeURIComponent(
+      Object.keys(params)
+        .sort()
+        .map(key => `${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`)
+        .join('&')
+    )
+  ].join('&')
+
+  const signingKey = `${encodeURIComponent(credentials.apiSecret)}&${encodeURIComponent(credentials.accessSecret)}`
+
+  return crypto
+    .createHmac('sha1', signingKey)
+    .update(signatureBaseString)
+    .digest('base64')
+}
+
+/**
+ * Generate OAuth Authorization header
+ */
+function generateOAuthHeader(method, url, credentials) {
+  const oauthParams = {
+    oauth_consumer_key: credentials.apiKey,
+    oauth_nonce: crypto.randomBytes(16).toString('hex'),
+    oauth_signature_method: 'HMAC-SHA1',
+    oauth_timestamp: Math.floor(Date.now() / 1000).toString(),
+    oauth_token: credentials.accessToken,
+    oauth_version: '1.0'
+  }
+
+  const signature = generateOAuthSignature(method, url, oauthParams, credentials)
+  oauthParams.oauth_signature = signature
+
+  const headerString = Object.keys(oauthParams)
+    .sort()
+    .map(key => `${encodeURIComponent(key)}="${encodeURIComponent(oauthParams[key])}"`)
+    .join(', ')
+
+  return `OAuth ${headerString}`
+}
+
+/**
+ * Format tweet with hashtags and URL
+ */
+function formatTweet(text, hashtags, url) {
+  let tweet = text
+
+  if (url) {
+    tweet += `\n\n${url}`
+  }
+
+  if (hashtags.length > 0) {
+    const hashtagStr = hashtags.map(h => `#${h.replace(/^#/, '')}`).join(' ')
+    tweet += `\n\n${hashtagStr}`
+  }
+
+  return tweet
+}
+
+/**
+ * Post tweet to Twitter
+ */
+async function postToTwitter(options) {
+  if (!options.text) {
+    console.error('❌ Error: No text provided')
+    console.error('Usage: node scripts/social/post-twitter.js "Your tweet here"')
+    process.exit(1)
+  }
+
+  const tweetText = formatTweet(options.text, options.hashtags, options.url)
+
+  // Check length
+  if (tweetText.length > 280) {
+    console.error(`❌ Error: Tweet too long (${tweetText.length}/280 characters)`)
+    console.error('Tweet preview:')
+    console.error(tweetText)
+    process.exit(1)
+  }
+
+  if (options.dryRun) {
+    console.log('🔵 [DRY RUN] Would post to Twitter:')
+    console.log('---')
+    console.log(`Tweet (${tweetText.length}/280 chars):`)
+    console.log(tweetText)
+    console.log('---')
+    return { dryRun: true }
+  }
+
+  const credentials = getCredentials()
+  if (!credentials) {
+    console.error('❌ Twitter credentials not configured')
+    console.error('Required environment variables:')
+    console.error('  TWITTER_API_KEY')
+    console.error('  TWITTER_API_SECRET')
+    console.error('  TWITTER_ACCESS_TOKEN')
+    console.error('  TWITTER_ACCESS_SECRET')
+    process.exit(1)
+  }
+
+  try {
+    const authHeader = generateOAuthHeader('POST', TWITTER_API_URL, credentials)
+
+    const response = await fetch(TWITTER_API_URL, {
+      method: 'POST',
+      headers: {
+        'Authorization': authHeader,
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({ text: tweetText })
+    })
+
+    const data = await response.json()
+
+    if (response.ok) {
+      const tweetUrl = `https://twitter.com/i/status/${data.data.id}`
+      console.log('✅ Posted to Twitter successfully!')
+      console.log(`   Tweet URL: ${tweetUrl}`)
+      return { success: true, id: data.data.id, url: tweetUrl }
+    } else {
+      console.error(`❌ Failed to post: ${JSON.stringify(data)}`)
+      return { error: true, data }
+    }
+  } catch (error) {
+    console.error('❌ Error:', error.message)
+    return { error: true, message: error.message }
+  }
+}
+
+// Run if called directly
+const options = parseArgs()
+postToTwitter(options)


### PR DESCRIPTION
## Summary
- Add a Claude Code sub-agent (`/social-post` slash command) for posting to Discord and Twitter/X
- Add standalone scripts for social media posting with dry-run support
- Add npm scripts for quick access: `social:discord`, `social:twitter`, `social:post`

## Changes
- **`.claude/commands/social-post.md`** - Interactive Claude Code slash command
- **`scripts/social/post-discord.js`** - Post to Discord via webhook
- **`scripts/social/post-twitter.js`** - Post to Twitter with OAuth 1.0a
- **`scripts/social/post-both.js`** - Cross-platform posting
- **`docs/ai/social-media-agent.md`** - Documentation
- **`package.json`** - Added npm scripts

## Usage
```bash
# Via npm
npm run social:discord "Your message"
npm run social:twitter "Your tweet"
npm run social:post "Announce on both platforms"

# All scripts support --dry-run
npm run social:discord -- --dry-run "Preview message"
```

## Test plan
- [x] Verified `post-discord.js --dry-run` works correctly
- [x] Verified `post-twitter.js --dry-run` works correctly
- [x] Verified `post-both.js --dry-run` works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)