### PR TITLE
feat(www): add blog image generation agent using OpenAI DALL-E

### DIFF
--- a/.claude/commands/blog-image.md
+++ b/.claude/commands/blog-image.md
@@ -1,0 +1,170 @@
+# Blog Image Generation Agent (ChatGPT DALL-E)
+
+Generate professional blog post images using OpenAI's DALL-E API for the topic: $ARGUMENTS
+
+## Instructions
+
+This agent generates high-quality, on-brand images for SonicJS blog posts using OpenAI's DALL-E image generation API.
+
+### 1. Image Requirements Analysis
+
+Based on the blog topic provided, determine:
+- **Image Type**: Hero image, diagram, illustration, or screenshot mockup
+- **Style**: Modern tech aesthetic, clean lines, professional
+- **Color Palette**: SonicJS brand colors (blue gradients, dark backgrounds, white accents)
+- **Dimensions**: 1200x630px (OpenGraph standard) or 1600x900px (hero image)
+
+### 2. Prompt Engineering
+
+Create an optimized DALL-E prompt following these guidelines:
+
+**Effective Prompt Structure**:
+```
+[Style] [Subject] [Setting/Context] [Color/Lighting] [Technical Details]
+```
+
+**Example Prompts**:
+- "Modern minimalist tech illustration of cloud computing with edge servers, blue gradient background, geometric shapes, professional business style, clean vector art"
+- "Abstract digital art showing data flowing through a global network, dark background with glowing blue nodes, futuristic tech aesthetic, 3D render"
+- "Isometric illustration of a developer workspace with code on screens showing CMS dashboard, soft lighting, modern flat design style"
+
+**Brand Guidelines for SonicJS Images**:
+- Primary colors: #3B82F6 (blue), #1E293B (dark slate), #F8FAFC (light)
+- Style: Modern, minimalist, tech-forward
+- Avoid: Cartoonish elements, stock photo clichés, cluttered compositions
+- Include: Clean typography space, professional atmosphere, development/cloud themes
+
+### 3. API Integration
+
+To generate images, use the OpenAI API with the following approach:
+
+**API Endpoint**: `https://api.openai.com/v1/images/generations`
+
+**Request Format**:
+```json
+{
+  "model": "dall-e-3",
+  "prompt": "[Your optimized prompt]",
+  "n": 1,
+  "size": "1792x1024",
+  "quality": "hd",
+  "style": "vivid"
+}
+```
+
+**Headers Required**:
+```
+Authorization: Bearer $OPENAI_API_KEY
+Content-Type: application/json
+```
+
+**Implementation Steps**:
+1. Construct the prompt based on the blog topic
+2. Make the API call to generate the image
+3. Download the generated image URL
+4. Save to the appropriate location
+5. Optimize the image for web (compress if needed)
+
+### 4. File Location
+
+Save generated images to: `www/public/images/blog/[blog-slug]/`
+
+**Naming Convention**:
+- Hero image: `hero.webp` or `hero.jpg`
+- Supporting images: `[description]-[number].webp`
+
+### 5. Output Deliverables
+
+After generating the image, provide:
+
+1. **Generated Image URL** (temporary, expires in 1 hour)
+2. **Suggested Filename**: Following naming convention
+3. **Alt Text**: Descriptive, SEO-friendly alt text (125 chars max)
+4. **Image Metadata**:
+   ```mdx
+   // Add to blog post frontmatter:
+   image: '/images/blog/[slug]/hero.webp'
+   imageAlt: '[Generated alt text]'
+   ```
+5. **Download Instructions**: How to save and optimize the image
+
+### 6. Prompt Templates by Blog Type
+
+**Tutorial Posts**:
+```
+Modern illustration showing [specific technology/concept], step-by-step visual guide aesthetic, clean flat design, blue and white color scheme, developer-friendly, educational infographic style
+```
+
+**Comparison Posts**:
+```
+Split-screen tech comparison visualization, [Product A] vs [Product B] concept, balanced composition, professional analysis theme, modern gradient background, corporate presentation style
+```
+
+**Technical Deep Dives**:
+```
+Abstract representation of [technical concept], architectural diagram style, interconnected nodes and data flow, dark theme with glowing accents, sophisticated tech aesthetic
+```
+
+**Use Case/Case Study**:
+```
+Professional business scenario illustration showing [use case], modern office/tech environment, success-oriented imagery, warm professional lighting, corporate but approachable
+```
+
+### 7. Quality Checklist
+
+Before finalizing the image:
+- [ ] Image is relevant to blog topic
+- [ ] No text in image (DALL-E struggles with text)
+- [ ] Colors align with SonicJS brand
+- [ ] Composition leaves space for title overlay if needed
+- [ ] Image is appropriate for professional tech blog
+- [ ] Alt text is descriptive and accessible
+
+### 8. Fallback Options
+
+If DALL-E generation fails or produces unsuitable results:
+
+1. **Retry with modified prompt**: Simplify or clarify the prompt
+2. **Alternative sources**: Suggest Unsplash, Pexels for stock alternatives
+3. **Placeholder**: Provide solid color gradient matching brand
+
+## Example Usage
+
+```
+/blog-image Building a REST API with SonicJS
+```
+
+**Generated Prompt**:
+"Modern minimalist illustration of REST API architecture, interconnected endpoints and data nodes, blueprint-style technical diagram, blue gradient on dark background, clean vector art style, professional developer documentation aesthetic"
+
+**Output**:
+- Image URL: [temporary URL]
+- Filename: `rest-api-hero.webp`
+- Alt text: "Illustration of REST API architecture showing interconnected endpoints and data flow patterns"
+
+## Environment Setup
+
+Ensure the following environment variable is configured:
+
+```bash
+# Add to your environment or .env file
+OPENAI_API_KEY=sk-your-api-key-here
+```
+
+For Cloudflare Workers deployment, add to `wrangler.toml`:
+```toml
+[vars]
+OPENAI_API_KEY = "sk-your-api-key-here"
+```
+
+Or use Cloudflare secrets:
+```bash
+wrangler secret put OPENAI_API_KEY
+```
+
+## Notes
+
+- DALL-E 3 costs approximately $0.040-0.120 per image depending on size/quality
+- Generated image URLs expire after 1 hour - download promptly
+- For batch generation, consider rate limiting (50 images/minute max)
+- Always review generated images for appropriateness before publishing

--- a/www/package.json
+++ b/www/package.json
@@ -16,7 +16,8 @@
     "type-check": "tsc --noEmit",
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",
     "deploy": "opennextjs-cloudflare build && opennextjs-cloudflare deploy",
-    "upload": "opennextjs-cloudflare build && opennextjs-cloudflare upload"
+    "upload": "opennextjs-cloudflare build && opennextjs-cloudflare upload",
+    "generate:blog-image": "node scripts/generate-blog-image.mjs"
   },
   "repository": {
     "type": "git",

--- a/www/scripts/generate-blog-image.mjs
+++ b/www/scripts/generate-blog-image.mjs
@@ -1,0 +1,271 @@
+#!/usr/bin/env node
+/**
+ * Blog Image Generator using OpenAI DALL-E API
+ *
+ * Usage:
+ *   node scripts/generate-blog-image.mjs "blog topic" [options]
+ *
+ * Options:
+ *   --slug <slug>     Blog post slug for file naming
+ *   --style <style>   Image style: vivid (default) or natural
+ *   --size <size>     Image size: 1024x1024, 1792x1024 (default), or 1024x1792
+ *   --quality <qual>  Image quality: standard or hd (default)
+ *   --output <path>   Custom output directory
+ *
+ * Environment:
+ *   OPENAI_API_KEY    Required: Your OpenAI API key
+ *
+ * Example:
+ *   OPENAI_API_KEY=sk-xxx node scripts/generate-blog-image.mjs "Building REST APIs with SonicJS" --slug rest-api-guide
+ */
+
+import { writeFileSync, mkdirSync, existsSync } from 'fs'
+import { join, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = dirname(__filename)
+
+// Parse command line arguments
+function parseArgs(args) {
+  const parsed = {
+    topic: '',
+    slug: '',
+    style: 'vivid',
+    size: '1792x1024',
+    quality: 'hd',
+    output: ''
+  }
+
+  let i = 0
+  while (i < args.length) {
+    const arg = args[i]
+    if (arg === '--slug' && args[i + 1]) {
+      parsed.slug = args[++i]
+    } else if (arg === '--style' && args[i + 1]) {
+      parsed.style = args[++i]
+    } else if (arg === '--size' && args[i + 1]) {
+      parsed.size = args[++i]
+    } else if (arg === '--quality' && args[i + 1]) {
+      parsed.quality = args[++i]
+    } else if (arg === '--output' && args[i + 1]) {
+      parsed.output = args[++i]
+    } else if (!arg.startsWith('--')) {
+      parsed.topic = arg
+    }
+    i++
+  }
+
+  return parsed
+}
+
+// Generate a slug from the topic if not provided
+function generateSlug(topic) {
+  return topic
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .substring(0, 50)
+    .replace(/-$/, '')
+}
+
+// Determine image type and create optimized prompt
+function createDallePrompt(topic) {
+  const topicLower = topic.toLowerCase()
+
+  // Detect blog type and customize prompt
+  let stylePrefix = ''
+  let contextSuffix = ''
+
+  if (topicLower.includes('vs') || topicLower.includes('comparison') || topicLower.includes('versus')) {
+    stylePrefix = 'Split-screen modern tech comparison visualization,'
+    contextSuffix = 'balanced composition showing two approaches, professional analysis theme'
+  } else if (topicLower.includes('tutorial') || topicLower.includes('guide') || topicLower.includes('how to')) {
+    stylePrefix = 'Modern educational illustration showing'
+    contextSuffix = 'step-by-step visual guide aesthetic, clean flat design, developer-friendly'
+  } else if (topicLower.includes('architecture') || topicLower.includes('deep dive') || topicLower.includes('under the hood')) {
+    stylePrefix = 'Abstract technical architecture visualization of'
+    contextSuffix = 'interconnected nodes and data flow, sophisticated engineering diagram style'
+  } else if (topicLower.includes('api') || topicLower.includes('rest') || topicLower.includes('graphql')) {
+    stylePrefix = 'Modern minimalist illustration of API architecture for'
+    contextSuffix = 'blueprint-style technical diagram, endpoints and data connections'
+  } else if (topicLower.includes('deploy') || topicLower.includes('cloud') || topicLower.includes('cloudflare')) {
+    stylePrefix = 'Futuristic cloud infrastructure illustration showing'
+    contextSuffix = 'global network with edge servers, cloud computing visualization'
+  } else if (topicLower.includes('database') || topicLower.includes('d1') || topicLower.includes('data')) {
+    stylePrefix = 'Modern data architecture illustration representing'
+    contextSuffix = 'database schemas and data relationships, clean technical visualization'
+  } else {
+    stylePrefix = 'Modern professional tech illustration representing'
+    contextSuffix = 'clean contemporary design, developer-focused aesthetic'
+  }
+
+  // Build the full prompt with SonicJS brand guidelines
+  const prompt = `${stylePrefix} ${topic}, ${contextSuffix}, blue gradient on dark slate background (#1E293B to #3B82F6), minimalist geometric shapes, no text in image, professional business quality, clean vector art style, soft ambient lighting, modern tech aesthetic suitable for a developer blog hero image`
+
+  return prompt
+}
+
+// Generate alt text for the image
+function generateAltText(topic) {
+  const cleanTopic = topic.replace(/['"]/g, '')
+  return `Illustration representing ${cleanTopic} for SonicJS blog`.substring(0, 125)
+}
+
+// Call OpenAI DALL-E API
+async function generateImage(prompt, options) {
+  const apiKey = process.env.OPENAI_API_KEY
+
+  if (!apiKey) {
+    throw new Error('OPENAI_API_KEY environment variable is required')
+  }
+
+  console.log('\n📝 DALL-E Prompt:')
+  console.log(prompt)
+  console.log('')
+
+  const response = await fetch('https://api.openai.com/v1/images/generations', {
+    method: 'POST',
+    headers: {
+      'Authorization': `Bearer ${apiKey}`,
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({
+      model: 'dall-e-3',
+      prompt: prompt,
+      n: 1,
+      size: options.size,
+      quality: options.quality,
+      style: options.style
+    })
+  })
+
+  if (!response.ok) {
+    const error = await response.json()
+    throw new Error(`OpenAI API error: ${error.error?.message || response.statusText}`)
+  }
+
+  const data = await response.json()
+  return data.data[0]
+}
+
+// Download image from URL
+async function downloadImage(url) {
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`Failed to download image: ${response.statusText}`)
+  }
+  return Buffer.from(await response.arrayBuffer())
+}
+
+// Main function
+async function main() {
+  const args = process.argv.slice(2)
+
+  if (args.length === 0 || args.includes('--help') || args.includes('-h')) {
+    console.log(`
+Blog Image Generator for SonicJS
+
+Usage:
+  node scripts/generate-blog-image.mjs "blog topic" [options]
+
+Options:
+  --slug <slug>     Blog post slug for file naming
+  --style <style>   Image style: vivid (default) or natural
+  --size <size>     Image size: 1024x1024, 1792x1024 (default), or 1024x1792
+  --quality <qual>  Image quality: standard or hd (default)
+  --output <path>   Custom output directory
+
+Environment:
+  OPENAI_API_KEY    Required: Your OpenAI API key
+
+Examples:
+  node scripts/generate-blog-image.mjs "Building REST APIs"
+  node scripts/generate-blog-image.mjs "SonicJS vs Strapi" --slug sonicjs-vs-strapi
+  node scripts/generate-blog-image.mjs "Edge Computing Guide" --style natural --quality standard
+`)
+    process.exit(0)
+  }
+
+  const options = parseArgs(args)
+
+  if (!options.topic) {
+    console.error('❌ Error: Blog topic is required')
+    process.exit(1)
+  }
+
+  // Generate slug if not provided
+  const slug = options.slug || generateSlug(options.topic)
+
+  // Determine output directory
+  const outputDir = options.output || join(__dirname, '../public/images/blog', slug)
+
+  console.log('🎨 Blog Image Generator')
+  console.log('=======================')
+  console.log(`Topic: ${options.topic}`)
+  console.log(`Slug: ${slug}`)
+  console.log(`Style: ${options.style}`)
+  console.log(`Size: ${options.size}`)
+  console.log(`Quality: ${options.quality}`)
+  console.log(`Output: ${outputDir}`)
+
+  try {
+    // Create the prompt
+    const prompt = createDallePrompt(options.topic)
+
+    // Generate the image
+    console.log('\n🔄 Generating image with DALL-E 3...')
+    const result = await generateImage(prompt, options)
+
+    console.log('\n✅ Image generated successfully!')
+    console.log(`\n🔗 Temporary URL (expires in 1 hour):`)
+    console.log(result.url)
+
+    if (result.revised_prompt) {
+      console.log('\n📝 Revised prompt (by DALL-E):')
+      console.log(result.revised_prompt)
+    }
+
+    // Download the image
+    console.log('\n📥 Downloading image...')
+    const imageBuffer = await downloadImage(result.url)
+
+    // Create output directory if it doesn't exist
+    if (!existsSync(outputDir)) {
+      mkdirSync(outputDir, { recursive: true })
+    }
+
+    // Save the image
+    const filename = 'hero.png'
+    const filepath = join(outputDir, filename)
+    writeFileSync(filepath, imageBuffer)
+    console.log(`\n💾 Saved to: ${filepath}`)
+
+    // Generate metadata
+    const altText = generateAltText(options.topic)
+    const relativePath = `/images/blog/${slug}/${filename}`
+
+    console.log('\n📋 Blog Post Metadata:')
+    console.log('----------------------')
+    console.log(`image: '${relativePath}'`)
+    console.log(`imageAlt: '${altText}'`)
+
+    console.log('\n📄 MDX Frontmatter:')
+    console.log('-------------------')
+    console.log(`export const metadata = {
+  // ... other metadata
+  openGraph: {
+    images: [{ url: '${relativePath}', alt: '${altText}' }]
+  }
+}`)
+
+    console.log('\n✨ Done!')
+
+  } catch (error) {
+    console.error('\n❌ Error:', error.message)
+    process.exit(1)
+  }
+}
+
+main()


### PR DESCRIPTION
## Summary

- Add `/blog-image` slash command agent for generating blog post images using OpenAI's DALL-E 3 API
- Create `generate-blog-image.mjs` utility script with full CLI support
- Auto-generate optimized prompts based on blog topic type (tutorials, comparisons, deep dives, etc.)

## Features

- **Slash Command**: Use `/blog-image [topic]` to generate images with brand guidelines
- **CLI Script**: `npm run generate:blog-image "topic"` with options for style, size, quality
- **Smart Prompts**: Automatically detects blog type and generates appropriate DALL-E prompts
- **Brand Consistency**: Uses SonicJS brand colors (#3B82F6 blue, #1E293B dark slate)
- **Auto-save**: Downloads and saves images to `www/public/images/blog/[slug]/`

## Usage

```bash
# Via slash command
/blog-image Building REST APIs with SonicJS

# Via CLI
OPENAI_API_KEY=sk-xxx npm run generate:blog-image "SonicJS vs Strapi" --slug sonicjs-vs-strapi
```

## Test plan

- [ ] Verify `/blog-image` command is available in Claude Code
- [ ] Test script with `--help` flag
- [ ] Generate test image with valid OpenAI API key
- [ ] Verify image saves to correct location

🤖 Generated with [Claude Code](https://claude.com/claude-code)