### PR TITLE
feat: load API keys from shared ~/Dropbox/Data/.env file

### DIFF
--- a/scripts/notify-discord.js
+++ b/scripts/notify-discord.js
@@ -4,16 +4,35 @@
  * Discord release notification script (Legacy)
  *
  * Posts a basic release notification to Discord when a new version is published.
- * Requires DISCORD_WEBHOOK_URL environment variable to be set.
  *
  * NOTE: This script is kept for backwards compatibility.
  * For AI-enhanced announcements (Discord + Twitter + WWW), use:
  *   npm run release:announce
  *
+ * Environment (loaded from ~/Dropbox/Data/.env):
+ *   DISCORD_WEBHOOK_URL - Discord webhook URL
+ *
  * @deprecated Use `npm run release:announce` for full release announcements
  */
 
 import fs from 'fs'
+import { existsSync, readFileSync } from 'fs'
+import { homedir } from 'os'
+
+// Load environment variables from shared .env file
+const envPath = `${homedir()}/Dropbox/Data/.env`
+if (existsSync(envPath)) {
+  const envContent = readFileSync(envPath, 'utf8')
+  for (const line of envContent.split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed && !trimmed.startsWith('#')) {
+      const [key, ...valueParts] = trimmed.split('=')
+      if (key && valueParts.length > 0) {
+        process.env[key] = valueParts.join('=')
+      }
+    }
+  }
+}
 import path from 'path'
 import { fileURLToPath } from 'url'
 

--- a/scripts/release/index.js
+++ b/scripts/release/index.js
@@ -19,7 +19,29 @@
  *   --skip-www        Skip WWW repository update
  *   --version <ver>   Override version number
  *   --notes <text>    Override release notes
+ *
+ * Environment (loaded from ~/Dropbox/Data/.env):
+ *   DISCORD_WEBHOOK_URL - Discord webhook URL
+ *   TWITTER_API_KEY, TWITTER_API_SECRET, etc. - Twitter credentials
  */
+
+import { existsSync, readFileSync } from 'fs'
+import { homedir } from 'os'
+
+// Load environment variables from shared .env file
+const envPath = `${homedir()}/Dropbox/Data/.env`
+if (existsSync(envPath)) {
+  const envContent = readFileSync(envPath, 'utf8')
+  for (const line of envContent.split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed && !trimmed.startsWith('#')) {
+      const [key, ...valueParts] = trimmed.split('=')
+      if (key && valueParts.length > 0) {
+        process.env[key] = valueParts.join('=')
+      }
+    }
+  }
+}
 
 import { generateContent, getReleaseInfo } from './generate-content.js'
 import { postToTwitter } from './post-twitter.js'

--- a/scripts/release/post-twitter.js
+++ b/scripts/release/post-twitter.js
@@ -5,9 +5,32 @@
  *
  * Uses Twitter API v2 to post release announcements as threads.
  * Requires OAuth 1.0a User Context authentication.
+ *
+ * Environment (loaded from ~/Dropbox/Data/.env):
+ *   TWITTER_API_KEY - Twitter API Key (Consumer Key)
+ *   TWITTER_API_SECRET - Twitter API Secret (Consumer Secret)
+ *   TWITTER_ACCESS_TOKEN - User Access Token
+ *   TWITTER_ACCESS_TOKEN_SECRET - User Access Token Secret
  */
 
 import crypto from 'crypto'
+import { existsSync, readFileSync } from 'fs'
+import { homedir } from 'os'
+
+// Load environment variables from shared .env file
+const envPath = `${homedir()}/Dropbox/Data/.env`
+if (existsSync(envPath)) {
+  const envContent = readFileSync(envPath, 'utf8')
+  for (const line of envContent.split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed && !trimmed.startsWith('#')) {
+      const [key, ...valueParts] = trimmed.split('=')
+      if (key && valueParts.length > 0) {
+        process.env[key] = valueParts.join('=')
+      }
+    }
+  }
+}
 
 const TWITTER_API_URL = 'https://api.twitter.com/2/tweets'
 
@@ -90,7 +113,7 @@ function getCredentials() {
   const apiKey = process.env.TWITTER_API_KEY
   const apiSecret = process.env.TWITTER_API_SECRET
   const accessToken = process.env.TWITTER_ACCESS_TOKEN
-  const accessSecret = process.env.TWITTER_ACCESS_SECRET
+  const accessSecret = process.env.TWITTER_ACCESS_TOKEN_SECRET
 
   if (!apiKey || !apiSecret || !accessToken || !accessSecret) {
     return null

--- a/scripts/social/post-both.js
+++ b/scripts/social/post-both.js
@@ -12,12 +12,29 @@
  *   node scripts/social/post-both.js --discord-only "Discord only message"
  *   node scripts/social/post-both.js --twitter-only "Twitter only message"
  *
- * Environment:
- *   DISCORD_WEBHOOK_URL - Discord webhook URL (optional)
+ * Environment (loaded from ~/Dropbox/Data/.env):
+ *   DISCORD_WEBHOOK_URL - Discord webhook URL
  *   TWITTER_API_KEY, TWITTER_API_SECRET, etc. - Twitter credentials
  */
 
 import { spawn } from 'child_process'
+import { existsSync, readFileSync } from 'fs'
+import { homedir } from 'os'
+
+// Load environment variables from shared .env file
+const envPath = `${homedir()}/Dropbox/Data/.env`
+if (existsSync(envPath)) {
+  const envContent = readFileSync(envPath, 'utf8')
+  for (const line of envContent.split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed && !trimmed.startsWith('#')) {
+      const [key, ...valueParts] = trimmed.split('=')
+      if (key && valueParts.length > 0) {
+        process.env[key] = valueParts.join('=')
+      }
+    }
+  }
+}
 import { fileURLToPath } from 'url'
 import path from 'path'
 

--- a/scripts/social/post-discord.js
+++ b/scripts/social/post-discord.js
@@ -10,11 +10,27 @@
  *   node scripts/social/post-discord.js --title "Title" --message "Message"
  *   node scripts/social/post-discord.js --dry-run "Test message"
  *
- * Environment:
- *   DISCORD_WEBHOOK_URL - Discord webhook URL (optional, uses default if not set)
+ * Environment (loaded from ~/Dropbox/Data/.env):
+ *   DISCORD_WEBHOOK_URL - Discord webhook URL
  */
 
-const DEFAULT_WEBHOOK = 'https://discord.com/api/webhooks/1443339433318285442/lnxdw64Wze72PjY8EhxPYF6bLGjqBwOi8EqwOnZxUFPo82E37o6myjQ1aO-8dzvsaStN'
+import { existsSync, readFileSync } from 'fs'
+import { homedir } from 'os'
+
+// Load environment variables from shared .env file
+const envPath = `${homedir()}/Dropbox/Data/.env`
+if (existsSync(envPath)) {
+  const envContent = readFileSync(envPath, 'utf8')
+  for (const line of envContent.split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed && !trimmed.startsWith('#')) {
+      const [key, ...valueParts] = trimmed.split('=')
+      if (key && valueParts.length > 0) {
+        process.env[key] = valueParts.join('=')
+      }
+    }
+  }
+}
 
 /**
  * Parse command line arguments
@@ -54,7 +70,13 @@ function parseArgs() {
  * Post message to Discord
  */
 async function postToDiscord(options) {
-  const webhookUrl = process.env.DISCORD_WEBHOOK_URL || DEFAULT_WEBHOOK
+  const webhookUrl = process.env.DISCORD_WEBHOOK_URL
+
+  if (!webhookUrl) {
+    console.error('❌ Error: DISCORD_WEBHOOK_URL not configured')
+    console.error('Set DISCORD_WEBHOOK_URL in ~/Dropbox/Data/.env')
+    process.exit(1)
+  }
 
   if (!options.message) {
     console.error('❌ Error: No message provided')

--- a/scripts/social/post-twitter.js
+++ b/scripts/social/post-twitter.js
@@ -10,14 +10,31 @@
  *   node scripts/social/post-twitter.js --text "Tweet" --hashtags "SonicJS,CMS"
  *   node scripts/social/post-twitter.js --dry-run "Test tweet"
  *
- * Environment:
+ * Environment (loaded from ~/Dropbox/Data/.env):
  *   TWITTER_API_KEY - Twitter API Key (Consumer Key)
  *   TWITTER_API_SECRET - Twitter API Secret (Consumer Secret)
  *   TWITTER_ACCESS_TOKEN - User Access Token
- *   TWITTER_ACCESS_SECRET - User Access Token Secret
+ *   TWITTER_ACCESS_TOKEN_SECRET - User Access Token Secret
  */
 
 import crypto from 'crypto'
+import { existsSync, readFileSync } from 'fs'
+import { homedir } from 'os'
+
+// Load environment variables from shared .env file
+const envPath = `${homedir()}/Dropbox/Data/.env`
+if (existsSync(envPath)) {
+  const envContent = readFileSync(envPath, 'utf8')
+  for (const line of envContent.split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed && !trimmed.startsWith('#')) {
+      const [key, ...valueParts] = trimmed.split('=')
+      if (key && valueParts.length > 0) {
+        process.env[key] = valueParts.join('=')
+      }
+    }
+  }
+}
 
 const TWITTER_API_URL = 'https://api.twitter.com/2/tweets'
 const DEFAULT_HASHTAGS = ['SonicJS', 'CloudflareCMS', 'OpenSource', 'Webdev']
@@ -65,7 +82,7 @@ function getCredentials() {
   const apiKey = process.env.TWITTER_API_KEY
   const apiSecret = process.env.TWITTER_API_SECRET
   const accessToken = process.env.TWITTER_ACCESS_TOKEN
-  const accessSecret = process.env.TWITTER_ACCESS_SECRET
+  const accessSecret = process.env.TWITTER_ACCESS_TOKEN_SECRET
 
   if (!apiKey || !apiSecret || !accessToken || !accessSecret) {
     return null
@@ -175,7 +192,7 @@ async function postToTwitter(options) {
     console.error('  TWITTER_API_KEY')
     console.error('  TWITTER_API_SECRET')
     console.error('  TWITTER_ACCESS_TOKEN')
-    console.error('  TWITTER_ACCESS_SECRET')
+    console.error('  TWITTER_ACCESS_TOKEN_SECRET')
     process.exit(1)
   }
 

--- a/www/scripts/generate-blog-image.mjs
+++ b/www/scripts/generate-blog-image.mjs
@@ -13,13 +13,29 @@
  *   --output <path>   Custom output directory
  *
  * Environment:
- *   OPENAI_API_KEY    Required: Your OpenAI API key
+ *   OPENAI_API_KEY    Required: Your OpenAI API key (loaded from ~/Dropbox/Data/.env)
  *
  * Example:
- *   OPENAI_API_KEY=sk-xxx node scripts/generate-blog-image.mjs "Building REST APIs with SonicJS" --slug rest-api-guide
+ *   node scripts/generate-blog-image.mjs "Building REST APIs with SonicJS" --slug rest-api-guide
  */
 
-import { writeFileSync, mkdirSync, existsSync } from 'fs'
+import { writeFileSync, mkdirSync, existsSync, readFileSync } from 'fs'
+import { homedir } from 'os'
+
+// Load environment variables from shared .env file
+const envPath = `${homedir()}/Dropbox/Data/.env`
+if (existsSync(envPath)) {
+  const envContent = readFileSync(envPath, 'utf8')
+  for (const line of envContent.split('\n')) {
+    const trimmed = line.trim()
+    if (trimmed && !trimmed.startsWith('#')) {
+      const [key, ...valueParts] = trimmed.split('=')
+      if (key && valueParts.length > 0) {
+        process.env[key] = valueParts.join('=')
+      }
+    }
+  }
+}
 import { join, dirname } from 'path'
 import { fileURLToPath } from 'url'
 


### PR DESCRIPTION
## Summary
- Update all social media and blog image agents to load environment variables from a centralized `~/Dropbox/Data/.env` file
- Simplifies configuration for local development by eliminating the need to manually set environment variables
- Includes OpenAI, Twitter/X, Discord, and GitHub credentials

## Test plan
- [x] Tested blog image generation with DALL-E using shared .env
- [ ] Test Discord posting with `node scripts/social/post-discord.js --dry-run "test"`
- [ ] Test Twitter posting with `node scripts/social/post-twitter.js --dry-run "test"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)