### PR TITLE
feat(tests): update Postman collection with latest routes and OTP testing

### DIFF
--- a/tests/postman/README.md
+++ b/tests/postman/README.md
@@ -1,203 +1,199 @@
-# SonicJS API Postman Collection
+# SonicJS Postman Collection
 
-Comprehensive API testing collection for SonicJS with automated authentication handling.
-
-## Features
-
-- **Automated Authentication**: No need to manually copy/paste tokens
-- **Pre-request Auto-login**: Automatically logs in if token is missing or expired
-- **Collection Variables**: Stores tokens, IDs, and other test data automatically
-- **Comprehensive Coverage**: All major API endpoints included
-- **Organized Structure**: Grouped by functional areas
+A comprehensive Postman collection for manually testing the SonicJS API.
 
 ## Quick Start
 
-### 1. Import Collection
+1. **Import into Postman**:
+   - Open Postman
+   - Click "Import" and select both files:
+     - `SonicJS-API.postman_collection.json`
+     - `SonicJS-API.postman_environment.json` (optional but recommended)
 
-1. Open Postman
-2. Click **Import** button
-3. Select `SonicJS-API.postman_collection.json`
-4. (Optional) Import `SonicJS-API.postman_environment.json` for environment variables
+2. **Start SonicJS locally**:
+   ```bash
+   npm run dev
+   ```
 
-### 2. Configure Environment (Optional)
+3. **Seed the admin user** (first time only):
+   - Run the "Seed Admin User" request in the Authentication folder
+   - Default credentials: `admin@sonicjs.com` / `sonicjs!`
 
-If you imported the environment file:
-1. Select "SonicJS Local Environment" from the environment dropdown
-2. Update values if needed:
-   - `baseUrl`: API base URL (default: `http://localhost:8787`)
-   - `testUserEmail`: Login email (default: `admin@test.com`)
-   - `testUserPassword`: Login password (default: `Admin123!`)
+4. **Start testing**:
+   - Run any endpoint - authentication is handled automatically
 
-If you didn't import the environment, the collection will use default values.
+## Features
 
-### 3. Start Testing
+### Auto-Authentication
+The collection includes a pre-request script that automatically:
+- Logs in if no token exists
+- Refreshes token if expired
+- Skips auth for public endpoints
 
-1. **First, seed an admin user** (if not already done):
-   - Run: `Authentication > Seed Admin User`
-   - This creates the default admin user
+### Collection Variables
+Variables are automatically managed:
+- `authToken` - JWT token (auto-populated on login)
+- `tokenExpiry` - Token expiration timestamp
+- `userId` - Current user ID
+- `testContentId` - ID for content operations
+- `testMediaId` - ID for media operations
+- `otpEmail` / `otpCode` - For OTP testing
 
-2. **Test any endpoint**:
-   - Simply run any request
-   - Authentication happens automatically
-   - Token is saved and reused
-
-## How Auto-Authentication Works
-
-The collection includes a pre-request script that:
-
-1. **Checks token status** before each request
-2. **Auto-logs in** if token is missing or expired
-3. **Saves token** to collection variables
-4. **Reuses token** for subsequent requests
-
-You never need to manually copy tokens or set authorization headers!
-
-## Collection Structure
+## API Coverage
 
 ### Public API
-- Health Check
-- OpenAPI Specification
-- List Collections
-- Get Content (with filtering)
-- Get Collection Content
+- `GET /health` - Root health check
+- `GET /api/health` - API health check
+- `GET /api/` - API info
+- `GET /api/collections` - List collections
+- `GET /api/content` - List content (with filters)
+- `GET /api/content/:id` - Get content by ID
+- `GET /api/collections/:name/content` - Get collection content
+
+### System API
+- `GET /api/system/health` - Detailed health check (DB, KV, R2)
+- `GET /api/system/info` - System information
+- `GET /api/system/stats` - Content, media, and user statistics
+- `GET /api/system/ping` - Database connectivity check
+- `GET /api/system/env` - Environment and feature flags
 
 ### Authentication
-- Seed Admin User
-- Register User
-- Login
-- Get Current User
-- Refresh Token
-- Logout
-- Request Password Reset
-- Reset Password
+- `POST /auth/seed-admin` - Create initial admin user
+- `POST /auth/register` - Register new user
+- `POST /auth/login` - Login with email/password
+- `GET /auth/me` - Get current user
+- `POST /auth/refresh` - Refresh JWT token
+- `POST /auth/logout` - Logout
+- `POST /auth/request-password-reset` - Request password reset
+- `POST /auth/reset-password` - Reset password with token
+
+### OTP Authentication (Passwordless)
+The OTP plugin provides passwordless login via email codes:
+- `POST /auth/otp/request` - Request OTP code for email
+- `POST /auth/otp/verify` - Verify OTP code and get token
+- `POST /auth/otp/resend` - Resend OTP code
+
+**Note**: In development mode, the OTP code is returned in the response (`dev_code` field) for easy testing.
+
+### Admin - Users
+- `GET /admin/users` - List users (with pagination, filters)
+- `GET /admin/users/:id` - Get user details
+- `POST /admin/users/new` - Create user
+- `PUT /admin/users/:id` - Update user
+- `POST /admin/users/:id/toggle` - Toggle user active status
+- `DELETE /admin/users/:id` - Delete user (soft delete)
+- `POST /admin/invite-user` - Invite user via email
+- `POST /admin/resend-invitation/:id` - Resend invitation
+- `DELETE /admin/cancel-invitation/:id` - Cancel invitation
+
+### Admin - Profile
+- `GET /admin/profile` - Get current user's profile
+- `PUT /admin/profile` - Update profile
+- `POST /admin/profile/password` - Change password
+- `POST /admin/profile/avatar` - Upload avatar
 
 ### Admin - Content
-- List Content (with pagination)
-- Create Content
-- Get Content by ID
-- Update Content
-- Duplicate Content
-- Get Content Versions
-- Restore Content Version
-- Bulk Actions
-- Delete Content
+- `GET /admin/content/` - List content
+- `POST /admin/content/` - Create content
+- `GET /admin/content/:id/edit` - Get content for editing
+- `PUT /admin/content/:id` - Update content
+- `POST /admin/content/duplicate` - Duplicate content
+- `GET /admin/content/:id/versions` - Get content versions
+- `POST /admin/content/:id/restore/:version` - Restore version
+- `POST /admin/content/bulk-action` - Bulk actions (publish, unpublish, delete)
+- `DELETE /admin/content/:id` - Delete content
 
 ### Admin - Media
-- List Media (with pagination and filtering)
-- Upload Media (supports multiple files)
-- Get Media by ID
-- Update Media Metadata (alt, caption, tags, folder)
-- Get Media Stats
-- List Media Folders
-- Bulk Media Actions (delete, move, tag)
-- Delete Media (soft delete)
-- Serve Media File (public access)
+- `GET /admin/media/` - List media files
+- `POST /api/media/upload` - Upload single file
+- `POST /api/media/upload-multiple` - Upload multiple files
+- `PATCH /api/media/:id` - Update metadata (alt, caption, tags, folder)
+- `POST /api/media/create-folder` - Create folder
+- `POST /api/media/bulk-move` - Move files to folder
+- `POST /api/media/bulk-delete` - Bulk delete files
+- `DELETE /api/media/:id` - Delete single file
+- `GET /files/:folder/:filename` - Serve media file (public)
 
 ### Admin - Plugins
-- List Plugins
-- Get Plugin Settings
-- Activate Plugin
-- Deactivate Plugin
-- Install Plugin
-- Uninstall Plugin
-- Update Plugin Settings
+- `GET /admin/plugins` - List all plugins
+- `GET /admin/plugins/:id` - Get plugin details
+- `POST /admin/plugins/:id/activate` - Activate plugin
+- `POST /admin/plugins/:id/deactivate` - Deactivate plugin
+- `POST /admin/plugins/install` - Install plugin
+- `POST /admin/plugins/:id/uninstall` - Uninstall plugin
+- `POST /admin/plugins/:id/settings` - Update plugin settings
 
 ### Admin - Settings
-- Get Migrations Status
-- Run Migrations
-- Validate Database Schema
-- Get All Settings
-- Update Settings
+- `GET /admin/settings/api/migrations/status` - Migration status
+- `POST /admin/settings/api/migrations/run` - Run migrations
+- `GET /admin/settings/api/migrations/validate` - Validate schema
+- `GET /admin/settings/api/database-tools/stats` - Database stats
+- `GET /admin/settings/api/database-tools/validate` - Validate database
+- `POST /admin/settings/api/database-tools/backup` - Create backup
+- `POST /admin/settings/api/database-tools/truncate` - Truncate tables
+- `POST /admin/settings/general` - Update general settings
 
-## Collection Variables
+### Admin - Activity Logs
+- `GET /admin/activity-logs` - View activity logs (with filters)
+- `GET /admin/activity-logs/export` - Export logs as CSV
 
-The collection automatically manages these variables:
+### Admin - Dashboard API
+- `GET /admin/api/stats` - Dashboard statistics
+- `GET /admin/api/storage` - Storage information
+- `GET /admin/api/activity` - Recent activity
 
-| Variable | Description | Auto-populated |
-|----------|-------------|----------------|
-| `baseUrl` | API base URL | Manual |
-| `authToken` | JWT authentication token | Yes (on login) |
-| `tokenExpiry` | Token expiration timestamp | Yes (on login) |
-| `userId` | Current user ID | Yes (on login) |
-| `userEmail` | Current user email | Yes (on login) |
-| `testContentId` | Last created content ID | Yes (on create) |
-| `testMediaId` | Last uploaded media ID | Yes (on upload) |
-| `testPluginId` | Plugin ID for testing | Manual (default: database-tools) |
+## Environment Variables
 
-## Environment Variables (Optional)
-
-Set these in your Postman environment for custom configurations:
-
-| Variable | Description | Default |
-|----------|-------------|---------|
-| `testUserEmail` | Email for auto-login | admin@test.com |
-| `testUserPassword` | Password for auto-login | Admin123! |
+The environment file provides:
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `baseUrl` | `http://localhost:8787` | SonicJS server URL |
+| `testUserEmail` | `admin@sonicjs.com` | Default admin email |
+| `testUserPassword` | `sonicjs!` | Default admin password |
+| `otpTestEmail` | `otp-test@example.com` | Email for OTP testing |
 
 ## Testing Workflow Examples
 
-### Complete Content Workflow
+### OTP Login Flow
+1. Set `otpEmail` variable to your test email
+2. Run: `OTP Authentication > Request OTP Code`
+   - In dev mode, the code is saved to `otpCode` automatically
+3. Run: `OTP Authentication > Verify OTP Code`
+   - Token is saved for subsequent requests
 
+### Complete Content Workflow
 1. Run: `Authentication > Seed Admin User` (first time only)
 2. Run: `Admin - Content > Create Content`
    - Creates content and saves ID to `{{testContentId}}`
 3. Run: `Admin - Content > Get Content by ID`
-   - Uses saved `{{testContentId}}`
 4. Run: `Admin - Content > Update Content`
-   - Updates the same content
 5. Run: `Admin - Content > Delete Content`
-   - Soft deletes the content
 
 ### Media Upload & Management
-
-1. Run: `Admin - Media > Upload Media`
-   - Upload a file (select file in form-data)
+1. Run: `Admin - Media > Upload Media (Single)`
+   - Select a file in form-data
    - Media ID saved to `{{testMediaId}}`
 2. Run: `Admin - Media > Update Media Metadata`
-   - Updates the uploaded file's metadata
-3. Run: `Admin - Media > Get Media Stats`
-   - View storage statistics
+3. Run: `Admin - Media > Create Folder`
+4. Run: `Admin - Media > Bulk Move Files`
 
-### Plugin Management
+## Tips
 
-1. Run: `Admin - Plugins > List Plugins`
-   - See all available plugins
-2. Run: `Admin - Plugins > Activate Plugin`
-   - Activates `{{testPluginId}}` (default: database-tools)
-3. Run: `Admin - Plugins > Get Plugin Settings`
-   - View plugin configuration
-4. Run: `Admin - Plugins > Update Plugin Settings`
-   - Modify plugin settings
+1. **Run requests in order**: For CRUD operations, create → read → update → delete
+2. **Check console**: Response scripts log useful info to Postman console
+3. **Modify body data**: Edit request bodies to test different scenarios
+4. **Enable/disable query params**: Use Postman's checkboxes to toggle filters
+5. **OTP Testing**: The OTP code is auto-saved to `otpCode` variable in dev mode
 
-## Tips & Tricks
+## Troubleshooting
 
-### Viewing Saved Variables
+**401 Unauthorized**: Token may be expired. Run "Login" request or let auto-login handle it.
 
-1. Click **Variables** tab in the collection
-2. See all auto-populated values
-3. Manually edit if needed
+**404 Not Found**: Check that the resource ID variables (`testContentId`, etc.) are set.
 
-### Clearing Authentication
+**500 Server Error**: Check SonicJS logs for details. May need to run migrations first.
 
-Run: `Authentication > Logout` to clear saved token
-
-### Testing Different Users
-
-1. Update environment variables `testUserEmail` and `testUserPassword`
-2. Run: `Authentication > Logout`
-3. Run any protected endpoint (will auto-login with new credentials)
-
-### Debugging Auto-Login
-
-1. Open Postman Console (View > Show Postman Console)
-2. Run any request
-3. Look for "Auto-login successful!" or error messages
-
-### Running Collections
-
-Use Postman Collection Runner to:
-1. Run all requests in sequence
-2. Test full workflows
-3. Generate test reports
+**OTP endpoints not working**: Ensure the OTP Login plugin is activated in Admin > Plugins.
 
 ## Request Body Examples
 
@@ -212,34 +208,24 @@ Use Postman Collection Runner to:
 }
 ```
 
-**Default Required Fields:**
-- `email` (valid email format, minimum 5 characters)
-- `password` (minimum 8 characters)
-- `username` (minimum 3 characters)
-- `firstName` (minimum 1 character)
-- `lastName` (minimum 1 character)
-
-**Note:** Registration field requirements are **configurable** in the Authentication System plugin settings. Administrators can:
-- Make any field optional/required
-- Adjust minimum length requirements
-- Add password complexity requirements (uppercase, lowercase, numbers, special characters)
-- Configure default user roles
-
-To configure these settings:
-1. Navigate to **Admin > Plugins**
-2. Click on **Authentication System** plugin
-3. Go to **Settings** tab
-4. Adjust field requirements as needed
-
-Fields marked as optional in settings can be omitted from registration requests.
+### Create Content
+```json
+{
+  "title": "My Page Title",
+  "slug": "my-page",
+  "collection": "pages",
+  "status": "draft",
+  "fields": {
+    "body": "Page content here",
+    "excerpt": "Short description"
+  }
+}
+```
 
 ### Upload Media
 Uses `multipart/form-data`:
-- `files` (File or File array) - **Required**
+- `file` (File) - Required
 - `folder` (string) - Optional, default: "uploads"
-- `alt` (string) - Optional, alt text for images
-- `caption` (string) - Optional
-- `tags` (string) - Optional, comma-separated
 
 ### Update Media Metadata
 ```json
@@ -251,62 +237,7 @@ Uses `multipart/form-data`:
 }
 ```
 
-All fields are optional. Only included fields will be updated.
-
-## Common Issues
-
-### "Unauthorized" Errors
-
-- Token might be invalid
-- Run: `Authentication > Logout` then try again
-- Check console for auto-login errors
-
-### "Token expired" Messages
-
-- Should auto-refresh automatically
-- If persists, manually run: `Authentication > Refresh Token`
-
-### Variables Not Populating
-
-- Check **Tests** tab in requests for post-response scripts
-- Verify response is JSON format
-- Check Postman Console for errors
-
-### Validation Errors
-
-If you get validation errors:
-1. Check the "Request Body Examples" section above
-2. Ensure all required fields are included
-3. Verify field formats (email format, minimum lengths, etc.)
-4. Check Postman Console for detailed error messages
-
-## API Server Setup
-
-Ensure your SonicJS server is running:
-
-```bash
-# Development
-npm run dev
-
-# Or with specific port
-npm run dev -- --port 8787
-```
-
 ## Additional Resources
 
 - [SonicJS Documentation](https://github.com/lane711/sonicjs)
 - [Postman Learning Center](https://learning.postman.com/)
-- [Collection Variables](https://learning.postman.com/docs/sending-requests/variables/)
-
-## Contributing
-
-Found an issue or want to add more tests? Contributions welcome!
-
-1. Add new requests to appropriate folders
-2. Include test scripts to save IDs/variables
-3. Document in this README
-4. Test the full workflow
-
-## License
-
-Same as SonicJS project license.

--- a/tests/postman/SonicJS-API.postman_collection.json
+++ b/tests/postman/SonicJS-API.postman_collection.json
@@ -3,7 +3,7 @@
     "name": "SonicJS API Testing",
     "description": "Comprehensive API testing collection for SonicJS with automated authentication",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
-    "version": "1.0.0"
+    "version": "2.0.0"
   },
   "auth": {
     "type": "bearer",
@@ -28,7 +28,7 @@
           "",
           "// Skip auth for auth endpoints themselves",
           "const requestUrl = pm.request.url.toString();",
-          "if (requestUrl.includes('/auth/login') || requestUrl.includes('/auth/register') || requestUrl.includes('/auth/seed-admin') || requestUrl.includes('/api/health')) {",
+          "if (requestUrl.includes('/auth/login') || requestUrl.includes('/auth/register') || requestUrl.includes('/auth/seed-admin') || requestUrl.includes('/auth/otp/') || requestUrl.includes('/api/health') || requestUrl.includes('/api/system/')) {",
           "  return;",
           "}",
           "",
@@ -45,8 +45,8 @@
           "    body: {",
           "      mode: 'raw',",
           "      raw: JSON.stringify({",
-          "        email: pm.environment.get('testUserEmail') || 'admin@test.com',",
-          "        password: pm.environment.get('testUserPassword') || 'Admin123!'",
+          "        email: pm.environment.get('testUserEmail') || 'admin@sonicjs.com',",
+          "        password: pm.environment.get('testUserPassword') || 'sonicjs!'",
           "      })",
           "    }",
           "  };",
@@ -117,6 +117,21 @@
       "key": "testPluginId",
       "value": "database-tools",
       "type": "string"
+    },
+    {
+      "key": "testUserId",
+      "value": "",
+      "type": "string"
+    },
+    {
+      "key": "otpEmail",
+      "value": "test@example.com",
+      "type": "string"
+    },
+    {
+      "key": "otpCode",
+      "value": "",
+      "type": "string"
     }
   ],
   "item": [
@@ -124,7 +139,22 @@
       "name": "Public API",
       "item": [
         {
-          "name": "Health Check",
+          "name": "Health Check (Root)",
+          "request": {
+            "auth": {
+              "type": "noauth"
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/health",
+              "host": ["{{baseUrl}}"],
+              "path": ["health"]
+            }
+          }
+        },
+        {
+          "name": "API Health Check",
           "request": {
             "auth": {
               "type": "noauth"
@@ -139,7 +169,7 @@
           }
         },
         {
-          "name": "Get OpenAPI Spec",
+          "name": "Get API Info",
           "request": {
             "auth": {
               "type": "noauth"
@@ -212,6 +242,21 @@
           }
         },
         {
+          "name": "Get Content by ID",
+          "request": {
+            "auth": {
+              "type": "noauth"
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/content/{{testContentId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "content", "{{testContentId}}"]
+            }
+          }
+        },
+        {
           "name": "Get Collection Content",
           "request": {
             "auth": {
@@ -223,6 +268,86 @@
               "raw": "{{baseUrl}}/api/collections/pages/content",
               "host": ["{{baseUrl}}"],
               "path": ["api", "collections", "pages", "content"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "System API",
+      "item": [
+        {
+          "name": "System Health Check",
+          "request": {
+            "auth": {
+              "type": "noauth"
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/system/health",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "system", "health"]
+            }
+          }
+        },
+        {
+          "name": "System Info",
+          "request": {
+            "auth": {
+              "type": "noauth"
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/system/info",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "system", "info"]
+            }
+          }
+        },
+        {
+          "name": "System Stats",
+          "request": {
+            "auth": {
+              "type": "noauth"
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/system/stats",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "system", "stats"]
+            }
+          }
+        },
+        {
+          "name": "System Ping",
+          "request": {
+            "auth": {
+              "type": "noauth"
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/system/ping",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "system", "ping"]
+            }
+          }
+        },
+        {
+          "name": "System Environment",
+          "request": {
+            "auth": {
+              "type": "noauth"
+            },
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/api/system/env",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "system", "env"]
             }
           }
         }
@@ -259,7 +384,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"email\": \"admin@test.com\",\n  \"password\": \"Admin123!\",\n  \"name\": \"Test Admin\"\n}"
+              "raw": "{\n  \"email\": \"admin@sonicjs.com\",\n  \"password\": \"sonicjs!\",\n  \"name\": \"Admin User\"\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/auth/seed-admin",
@@ -275,7 +400,7 @@
               "listen": "test",
               "script": {
                 "exec": [
-                  "if (pm.response.code === 200) {",
+                  "if (pm.response.code === 200 || pm.response.code === 201) {",
                   "  const jsonData = pm.response.json();",
                   "  pm.collectionVariables.set('authToken', jsonData.token);",
                   "  pm.collectionVariables.set('userId', jsonData.user.id);",
@@ -345,7 +470,7 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"email\": \"admin@test.com\",\n  \"password\": \"Admin123!\"\n}"
+              "raw": "{\n  \"email\": \"admin@sonicjs.com\",\n  \"password\": \"sonicjs!\"\n}"
             },
             "url": {
               "raw": "{{baseUrl}}/auth/login",
@@ -428,12 +553,18 @@
             "header": [
               {
                 "key": "Content-Type",
-                "value": "application/json"
+                "value": "application/x-www-form-urlencoded"
               }
             ],
             "body": {
-              "mode": "raw",
-              "raw": "{\n  \"email\": \"admin@test.com\"\n}"
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "email",
+                  "value": "admin@sonicjs.com",
+                  "type": "text"
+                }
+              ]
             },
             "url": {
               "raw": "{{baseUrl}}/auth/request-password-reset",
@@ -452,17 +583,594 @@
             "header": [
               {
                 "key": "Content-Type",
-                "value": "application/json"
+                "value": "application/x-www-form-urlencoded"
               }
             ],
             "body": {
-              "mode": "raw",
-              "raw": "{\n  \"token\": \"reset-token-here\",\n  \"password\": \"NewPassword123!\"\n}"
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "token",
+                  "value": "reset-token-here",
+                  "type": "text"
+                },
+                {
+                  "key": "password",
+                  "value": "NewPassword123!",
+                  "type": "text"
+                },
+                {
+                  "key": "confirm_password",
+                  "value": "NewPassword123!",
+                  "type": "text"
+                }
+              ]
             },
             "url": {
               "raw": "{{baseUrl}}/auth/reset-password",
               "host": ["{{baseUrl}}"],
               "path": ["auth", "reset-password"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "OTP Authentication",
+      "description": "Passwordless authentication via email one-time codes. The OTP plugin must be active for these endpoints to work.",
+      "item": [
+        {
+          "name": "Request OTP Code",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "  const jsonData = pm.response.json();",
+                  "  console.log('OTP Response:', jsonData);",
+                  "  ",
+                  "  // In development mode, the code is returned in the response",
+                  "  if (jsonData.dev_code) {",
+                  "    pm.collectionVariables.set('otpCode', jsonData.dev_code);",
+                  "    console.log('Development OTP Code saved:', jsonData.dev_code);",
+                  "  }",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "noauth"
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{otpEmail}}\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/auth/otp/request",
+              "host": ["{{baseUrl}}"],
+              "path": ["auth", "otp", "request"]
+            }
+          }
+        },
+        {
+          "name": "Verify OTP Code",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "  const jsonData = pm.response.json();",
+                  "  console.log('OTP Verification Response:', jsonData);",
+                  "  ",
+                  "  if (jsonData.success) {",
+                  "    console.log('OTP verification successful!');",
+                  "    // If a token is returned, save it",
+                  "    if (jsonData.token) {",
+                  "      pm.collectionVariables.set('authToken', jsonData.token);",
+                  "      const expiryTime = Date.now() + (60 * 60 * 1000);",
+                  "      pm.collectionVariables.set('tokenExpiry', expiryTime);",
+                  "    }",
+                  "  }",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "noauth"
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{otpEmail}}\",\n  \"code\": \"{{otpCode}}\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/auth/otp/verify",
+              "host": ["{{baseUrl}}"],
+              "path": ["auth", "otp", "verify"]
+            }
+          }
+        },
+        {
+          "name": "Resend OTP Code",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "if (pm.response.code === 200) {",
+                  "  const jsonData = pm.response.json();",
+                  "  console.log('OTP Resend Response:', jsonData);",
+                  "  ",
+                  "  // In development mode, the new code is returned in the response",
+                  "  if (jsonData.dev_code) {",
+                  "    pm.collectionVariables.set('otpCode', jsonData.dev_code);",
+                  "    console.log('New Development OTP Code saved:', jsonData.dev_code);",
+                  "  }",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "auth": {
+              "type": "noauth"
+            },
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"email\": \"{{otpEmail}}\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/auth/otp/resend",
+              "host": ["{{baseUrl}}"],
+              "path": ["auth", "otp", "resend"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Admin - Users",
+      "item": [
+        {
+          "name": "List Users",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Accept",
+                "value": "application/json"
+              }
+            ],
+            "url": {
+              "raw": "{{baseUrl}}/admin/users?page=1&limit=20&status=active",
+              "host": ["{{baseUrl}}"],
+              "path": ["admin", "users"],
+              "query": [
+                {
+                  "key": "page",
+                  "value": "1"
+                },
+                {
+                  "key": "limit",
+                  "value": "20"
+                },
+                {
+                  "key": "status",
+                  "value": "active"
+                },
+                {
+                  "key": "search",
+                  "value": "",
+                  "disabled": true
+                },
+                {
+                  "key": "role",
+                  "value": "admin",
+                  "disabled": true
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Get User by ID",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/admin/users/{{testUserId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["admin", "users", "{{testUserId}}"]
+            }
+          }
+        },
+        {
+          "name": "Create User",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "// Check for redirect (successful creation redirects)",
+                  "if (pm.response.code === 302 || pm.response.code === 200) {",
+                  "  console.log('User created successfully');",
+                  "}"
+                ]
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/x-www-form-urlencoded"
+              }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "email",
+                  "value": "newuser@example.com",
+                  "type": "text"
+                },
+                {
+                  "key": "username",
+                  "value": "newuser",
+                  "type": "text"
+                },
+                {
+                  "key": "first_name",
+                  "value": "New",
+                  "type": "text"
+                },
+                {
+                  "key": "last_name",
+                  "value": "User",
+                  "type": "text"
+                },
+                {
+                  "key": "password",
+                  "value": "Password123!",
+                  "type": "text"
+                },
+                {
+                  "key": "confirm_password",
+                  "value": "Password123!",
+                  "type": "text"
+                },
+                {
+                  "key": "role",
+                  "value": "viewer",
+                  "type": "text"
+                },
+                {
+                  "key": "is_active",
+                  "value": "1",
+                  "type": "text"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/admin/users/new",
+              "host": ["{{baseUrl}}"],
+              "path": ["admin", "users", "new"]
+            }
+          }
+        },
+        {
+          "name": "Update User",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/x-www-form-urlencoded"
+              }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "email",
+                  "value": "updated@example.com",
+                  "type": "text"
+                },
+                {
+                  "key": "username",
+                  "value": "updateduser",
+                  "type": "text"
+                },
+                {
+                  "key": "first_name",
+                  "value": "Updated",
+                  "type": "text"
+                },
+                {
+                  "key": "last_name",
+                  "value": "User",
+                  "type": "text"
+                },
+                {
+                  "key": "role",
+                  "value": "editor",
+                  "type": "text"
+                },
+                {
+                  "key": "is_active",
+                  "value": "1",
+                  "type": "text"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/admin/users/{{testUserId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["admin", "users", "{{testUserId}}"]
+            }
+          }
+        },
+        {
+          "name": "Toggle User Status",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"active\": false\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/admin/users/{{testUserId}}/toggle",
+              "host": ["{{baseUrl}}"],
+              "path": ["admin", "users", "{{testUserId}}", "toggle"]
+            }
+          }
+        },
+        {
+          "name": "Delete User (Soft)",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"hardDelete\": false\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/admin/users/{{testUserId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["admin", "users", "{{testUserId}}"]
+            }
+          }
+        },
+        {
+          "name": "Invite User",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/x-www-form-urlencoded"
+              }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "email",
+                  "value": "invited@example.com",
+                  "type": "text"
+                },
+                {
+                  "key": "first_name",
+                  "value": "Invited",
+                  "type": "text"
+                },
+                {
+                  "key": "last_name",
+                  "value": "User",
+                  "type": "text"
+                },
+                {
+                  "key": "role",
+                  "value": "editor",
+                  "type": "text"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/admin/invite-user",
+              "host": ["{{baseUrl}}"],
+              "path": ["admin", "invite-user"]
+            }
+          }
+        },
+        {
+          "name": "Resend Invitation",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/admin/resend-invitation/{{testUserId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["admin", "resend-invitation", "{{testUserId}}"]
+            }
+          }
+        },
+        {
+          "name": "Cancel Invitation",
+          "request": {
+            "method": "DELETE",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/admin/cancel-invitation/{{testUserId}}",
+              "host": ["{{baseUrl}}"],
+              "path": ["admin", "cancel-invitation", "{{testUserId}}"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Admin - Profile",
+      "item": [
+        {
+          "name": "Get Profile",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/admin/profile",
+              "host": ["{{baseUrl}}"],
+              "path": ["admin", "profile"]
+            }
+          }
+        },
+        {
+          "name": "Update Profile",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/x-www-form-urlencoded"
+              }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "first_name",
+                  "value": "Updated",
+                  "type": "text"
+                },
+                {
+                  "key": "last_name",
+                  "value": "Name",
+                  "type": "text"
+                },
+                {
+                  "key": "username",
+                  "value": "updatedadmin",
+                  "type": "text"
+                },
+                {
+                  "key": "email",
+                  "value": "admin@sonicjs.com",
+                  "type": "text"
+                },
+                {
+                  "key": "timezone",
+                  "value": "America/New_York",
+                  "type": "text"
+                },
+                {
+                  "key": "language",
+                  "value": "en",
+                  "type": "text"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/admin/profile",
+              "host": ["{{baseUrl}}"],
+              "path": ["admin", "profile"]
+            }
+          }
+        },
+        {
+          "name": "Change Password",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/x-www-form-urlencoded"
+              }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "current_password",
+                  "value": "sonicjs!",
+                  "type": "text"
+                },
+                {
+                  "key": "new_password",
+                  "value": "NewPassword123!",
+                  "type": "text"
+                },
+                {
+                  "key": "confirm_password",
+                  "value": "NewPassword123!",
+                  "type": "text"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/admin/profile/password",
+              "host": ["{{baseUrl}}"],
+              "path": ["admin", "profile", "password"]
+            }
+          }
+        },
+        {
+          "name": "Upload Avatar",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "avatar",
+                  "type": "file",
+                  "src": [],
+                  "description": "Select an image file (JPEG, PNG, GIF, or WebP)"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/admin/profile/avatar",
+              "host": ["{{baseUrl}}"],
+              "path": ["admin", "profile", "avatar"]
             }
           }
         }
@@ -511,7 +1219,6 @@
               "script": {
                 "exec": [
                   "if (pm.response.code === 200 || pm.response.code === 201) {",
-                  "  // Try to extract ID from response",
                   "  try {",
                   "    const jsonData = pm.response.json();",
                   "    if (jsonData.id) {",
@@ -667,9 +1374,9 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/media/?page=1&limit=20",
+              "raw": "{{baseUrl}}/admin/media/?page=1&limit=20",
               "host": ["{{baseUrl}}"],
-              "path": ["media", ""],
+              "path": ["admin", "media", ""],
               "query": [
                 {
                   "key": "page",
@@ -694,7 +1401,7 @@
           }
         },
         {
-          "name": "Upload Media",
+          "name": "Upload Media (Single)",
           "event": [
             {
               "listen": "test",
@@ -703,9 +1410,9 @@
                   "if (pm.response.code === 200 || pm.response.code === 201) {",
                   "  try {",
                   "    const jsonData = pm.response.json();",
-                  "    if (jsonData.id) {",
-                  "      pm.collectionVariables.set('testMediaId', jsonData.id);",
-                  "      console.log('Media uploaded with ID:', jsonData.id);",
+                  "    if (jsonData.file && jsonData.file.id) {",
+                  "      pm.collectionVariables.set('testMediaId', jsonData.file.id);",
+                  "      console.log('Media uploaded with ID:', jsonData.file.id);",
                   "    }",
                   "  } catch (e) {",
                   "    console.log('Response processing error');",
@@ -722,58 +1429,57 @@
               "mode": "formdata",
               "formdata": [
                 {
-                  "key": "files",
+                  "key": "file",
                   "type": "file",
                   "src": [],
-                  "description": "Select one or more files to upload"
+                  "description": "Select a file to upload"
                 },
                 {
                   "key": "folder",
                   "value": "uploads",
                   "type": "text"
-                },
-                {
-                  "key": "alt",
-                  "value": "Test image uploaded via Postman",
-                  "type": "text"
-                },
-                {
-                  "key": "caption",
-                  "value": "Test caption",
-                  "type": "text",
-                  "disabled": true
-                },
-                {
-                  "key": "tags",
-                  "value": "test,postman",
-                  "type": "text",
-                  "disabled": true
                 }
               ]
             },
             "url": {
-              "raw": "{{baseUrl}}/media/upload",
+              "raw": "{{baseUrl}}/api/media/upload",
               "host": ["{{baseUrl}}"],
-              "path": ["media", "upload"]
+              "path": ["api", "media", "upload"]
             }
           }
         },
         {
-          "name": "Get Media by ID",
+          "name": "Upload Media (Multiple)",
           "request": {
-            "method": "GET",
+            "method": "POST",
             "header": [],
+            "body": {
+              "mode": "formdata",
+              "formdata": [
+                {
+                  "key": "files",
+                  "type": "file",
+                  "src": [],
+                  "description": "Select multiple files to upload"
+                },
+                {
+                  "key": "folder",
+                  "value": "uploads",
+                  "type": "text"
+                }
+              ]
+            },
             "url": {
-              "raw": "{{baseUrl}}/media/{{testMediaId}}",
+              "raw": "{{baseUrl}}/api/media/upload-multiple",
               "host": ["{{baseUrl}}"],
-              "path": ["media", "{{testMediaId}}"]
+              "path": ["api", "media", "upload-multiple"]
             }
           }
         },
         {
           "name": "Update Media Metadata",
           "request": {
-            "method": "PUT",
+            "method": "PATCH",
             "header": [
               {
                 "key": "Content-Type",
@@ -785,38 +1491,14 @@
               "raw": "{\n  \"alt\": \"Updated alt text\",\n  \"caption\": \"Updated caption via Postman\",\n  \"tags\": [\"updated\", \"postman\"],\n  \"folder\": \"updated-folder\"\n}"
             },
             "url": {
-              "raw": "{{baseUrl}}/media/{{testMediaId}}",
+              "raw": "{{baseUrl}}/api/media/{{testMediaId}}",
               "host": ["{{baseUrl}}"],
-              "path": ["media", "{{testMediaId}}"]
+              "path": ["api", "media", "{{testMediaId}}"]
             }
           }
         },
         {
-          "name": "Get Media Stats",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/media/stats/overview",
-              "host": ["{{baseUrl}}"],
-              "path": ["media", "stats", "overview"]
-            }
-          }
-        },
-        {
-          "name": "List Media Folders",
-          "request": {
-            "method": "GET",
-            "header": [],
-            "url": {
-              "raw": "{{baseUrl}}/media/folders",
-              "host": ["{{baseUrl}}"],
-              "path": ["media", "folders"]
-            }
-          }
-        },
-        {
-          "name": "Bulk Media Actions",
+          "name": "Create Folder",
           "request": {
             "method": "POST",
             "header": [
@@ -827,12 +1509,54 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"action\": \"move\",\n  \"mediaIds\": [\"{{testMediaId}}\"],\n  \"folder\": \"archived\"\n}"
+              "raw": "{\n  \"folderName\": \"new-folder\"\n}"
             },
             "url": {
-              "raw": "{{baseUrl}}/media/bulk",
+              "raw": "{{baseUrl}}/api/media/create-folder",
               "host": ["{{baseUrl}}"],
-              "path": ["media", "bulk"]
+              "path": ["api", "media", "create-folder"]
+            }
+          }
+        },
+        {
+          "name": "Bulk Move Files",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"fileIds\": [\"{{testMediaId}}\"],\n  \"folder\": \"archived\"\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/media/bulk-move",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "media", "bulk-move"]
+            }
+          }
+        },
+        {
+          "name": "Bulk Delete Files",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"fileIds\": [\"{{testMediaId}}\"]\n}"
+            },
+            "url": {
+              "raw": "{{baseUrl}}/api/media/bulk-delete",
+              "host": ["{{baseUrl}}"],
+              "path": ["api", "media", "bulk-delete"]
             }
           }
         },
@@ -842,9 +1566,9 @@
             "method": "DELETE",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/media/{{testMediaId}}",
+              "raw": "{{baseUrl}}/api/media/{{testMediaId}}",
               "host": ["{{baseUrl}}"],
-              "path": ["media", "{{testMediaId}}"]
+              "path": ["api", "media", "{{testMediaId}}"]
             }
           }
         },
@@ -857,9 +1581,9 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/media/serve/example-file-key",
+              "raw": "{{baseUrl}}/files/uploads/example-file.jpg",
               "host": ["{{baseUrl}}"],
-              "path": ["media", "serve", "example-file-key"]
+              "path": ["files", "uploads", "example-file.jpg"]
             }
           }
         }
@@ -981,9 +1705,9 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/admin/api/migrations/status",
+              "raw": "{{baseUrl}}/admin/settings/api/migrations/status",
               "host": ["{{baseUrl}}"],
-              "path": ["admin", "api", "migrations", "status"]
+              "path": ["admin", "settings", "api", "migrations", "status"]
             }
           }
         },
@@ -993,9 +1717,9 @@
             "method": "POST",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/admin/api/migrations/run",
+              "raw": "{{baseUrl}}/admin/settings/api/migrations/run",
               "host": ["{{baseUrl}}"],
-              "path": ["admin", "api", "migrations", "run"]
+              "path": ["admin", "settings", "api", "migrations", "run"]
             }
           }
         },
@@ -1005,26 +1729,50 @@
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/admin/api/migrations/validate",
+              "raw": "{{baseUrl}}/admin/settings/api/migrations/validate",
               "host": ["{{baseUrl}}"],
-              "path": ["admin", "api", "migrations", "validate"]
+              "path": ["admin", "settings", "api", "migrations", "validate"]
             }
           }
         },
         {
-          "name": "Get All Settings",
+          "name": "Get Database Stats",
           "request": {
             "method": "GET",
             "header": [],
             "url": {
-              "raw": "{{baseUrl}}/admin/settings",
+              "raw": "{{baseUrl}}/admin/settings/api/database-tools/stats",
               "host": ["{{baseUrl}}"],
-              "path": ["admin", "settings"]
+              "path": ["admin", "settings", "api", "database-tools", "stats"]
             }
           }
         },
         {
-          "name": "Update Settings",
+          "name": "Validate Database",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/admin/settings/api/database-tools/validate",
+              "host": ["{{baseUrl}}"],
+              "path": ["admin", "settings", "api", "database-tools", "validate"]
+            }
+          }
+        },
+        {
+          "name": "Backup Database",
+          "request": {
+            "method": "POST",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/admin/settings/api/database-tools/backup",
+              "host": ["{{baseUrl}}"],
+              "path": ["admin", "settings", "api", "database-tools", "backup"]
+            }
+          }
+        },
+        {
+          "name": "Truncate Tables",
           "request": {
             "method": "POST",
             "header": [
@@ -1035,12 +1783,159 @@
             ],
             "body": {
               "mode": "raw",
-              "raw": "{\n  \"tab\": \"general\",\n  \"settings\": {\n    \"siteName\": \"My SonicJS Site\",\n    \"siteDescription\": \"A headless CMS\"\n  }\n}"
+              "raw": "{\n  \"tables\": [\"content\"],\n  \"confirm\": true\n}"
             },
             "url": {
-              "raw": "{{baseUrl}}/admin/settings",
+              "raw": "{{baseUrl}}/admin/settings/api/database-tools/truncate",
               "host": ["{{baseUrl}}"],
-              "path": ["admin", "settings"]
+              "path": ["admin", "settings", "api", "database-tools", "truncate"]
+            }
+          }
+        },
+        {
+          "name": "Update General Settings",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/x-www-form-urlencoded"
+              }
+            ],
+            "body": {
+              "mode": "urlencoded",
+              "urlencoded": [
+                {
+                  "key": "siteName",
+                  "value": "My SonicJS Site",
+                  "type": "text"
+                },
+                {
+                  "key": "siteDescription",
+                  "value": "A headless CMS powered by SonicJS",
+                  "type": "text"
+                },
+                {
+                  "key": "adminEmail",
+                  "value": "admin@sonicjs.com",
+                  "type": "text"
+                },
+                {
+                  "key": "timezone",
+                  "value": "UTC",
+                  "type": "text"
+                },
+                {
+                  "key": "language",
+                  "value": "en",
+                  "type": "text"
+                }
+              ]
+            },
+            "url": {
+              "raw": "{{baseUrl}}/admin/settings/general",
+              "host": ["{{baseUrl}}"],
+              "path": ["admin", "settings", "general"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Admin - Activity Logs",
+      "item": [
+        {
+          "name": "View Activity Logs",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/admin/activity-logs?page=1&limit=50",
+              "host": ["{{baseUrl}}"],
+              "path": ["admin", "activity-logs"],
+              "query": [
+                {
+                  "key": "page",
+                  "value": "1"
+                },
+                {
+                  "key": "limit",
+                  "value": "50"
+                },
+                {
+                  "key": "action",
+                  "value": "user.login",
+                  "disabled": true
+                },
+                {
+                  "key": "resource_type",
+                  "value": "users",
+                  "disabled": true
+                },
+                {
+                  "key": "date_from",
+                  "value": "2024-01-01",
+                  "disabled": true
+                },
+                {
+                  "key": "date_to",
+                  "value": "2024-12-31",
+                  "disabled": true
+                }
+              ]
+            }
+          }
+        },
+        {
+          "name": "Export Activity Logs (CSV)",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/admin/activity-logs/export",
+              "host": ["{{baseUrl}}"],
+              "path": ["admin", "activity-logs", "export"]
+            }
+          }
+        }
+      ]
+    },
+    {
+      "name": "Admin - Dashboard API",
+      "item": [
+        {
+          "name": "Get Dashboard Stats",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/admin/api/stats",
+              "host": ["{{baseUrl}}"],
+              "path": ["admin", "api", "stats"]
+            }
+          }
+        },
+        {
+          "name": "Get Storage Info",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/admin/api/storage",
+              "host": ["{{baseUrl}}"],
+              "path": ["admin", "api", "storage"]
+            }
+          }
+        },
+        {
+          "name": "Get Recent Activity",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{baseUrl}}/admin/api/activity",
+              "host": ["{{baseUrl}}"],
+              "path": ["admin", "api", "activity"]
             }
           }
         }

--- a/tests/postman/SonicJS-API.postman_environment.json
+++ b/tests/postman/SonicJS-API.postman_environment.json
@@ -10,18 +10,24 @@
     },
     {
       "key": "testUserEmail",
-      "value": "admin@test.com",
+      "value": "admin@sonicjs.com",
       "type": "default",
       "enabled": true
     },
     {
       "key": "testUserPassword",
-      "value": "Admin123!",
+      "value": "sonicjs!",
       "type": "secret",
+      "enabled": true
+    },
+    {
+      "key": "otpTestEmail",
+      "value": "otp-test@example.com",
+      "type": "default",
       "enabled": true
     }
   ],
   "_postman_variable_scope": "environment",
-  "_postman_exported_at": "2025-01-14T00:00:00.000Z",
+  "_postman_exported_at": "2025-12-22T00:00:00.000Z",
   "_postman_exported_using": "Postman/10.0.0"
 }

--- a/www/src/app/testing/page.mdx
+++ b/www/src/app/testing/page.mdx
@@ -1,13 +1,14 @@
 export const metadata = {
   title: 'Testing Guide - SonicJS',
   description:
-    'Comprehensive testing guide for SonicJS covering unit tests with Vitest and end-to-end testing with Playwright, including examples and best practices.',
+    'Comprehensive testing guide for SonicJS covering unit tests with Vitest, end-to-end testing with Playwright, and manual API testing with Postman.',
 }
 
 export const sections = [
   { title: 'Overview', id: 'overview' },
   { title: 'Testing Stack', id: 'testing-stack' },
   { title: 'Setup and Installation', id: 'setup-and-installation' },
+  { title: 'Manual API Testing with Postman', id: 'manual-api-testing-with-postman' },
   { title: 'Unit Testing with Vitest', id: 'unit-testing-with-vitest' },
   { title: 'End-to-End Testing with Playwright', id: 'end-to-end-testing-with-playwright' },
   { title: 'Running Tests', id: 'running-tests' },
@@ -100,8 +101,13 @@ As of the latest test run:
       title: '@vitest/coverage-v8',
       description: "Fast, accurate code coverage using V8's built-in coverage",
     },
+    {
+      icon: '📬',
+      title: 'Postman Collection',
+      description: 'Manual API testing with auto-auth and full endpoint coverage',
+    },
   ]}
-  columns={3}
+  columns={4}
 />
 
 ### Why These Tools?
@@ -109,6 +115,7 @@ As of the latest test run:
 - **Vitest** - Fast, Vite-native test runner with excellent TypeScript support
 - **Playwright** - Reliable cross-browser testing with powerful debugging capabilities
 - **Coverage-v8** - Fast, accurate code coverage using V8's built-in coverage
+- **Postman** - Interactive API testing for development, debugging, and exploration
 
 ---
 
@@ -135,6 +142,110 @@ The project includes pre-configured test setups:
 - `vitest.config.ts` - Vitest configuration
 - `playwright.config.ts` - Playwright configuration
 - `tests/e2e/utils/test-helpers.ts` - Shared test utilities
+
+---
+
+## Manual API Testing with Postman
+
+SonicJS includes a comprehensive Postman collection for manually testing all API endpoints. This is useful for exploring the API, debugging issues, and testing new features during development.
+
+### Quick Start
+
+<CodeGroup title="Import the Collection">
+
+```bash
+# Collection and environment files are located at:
+tests/postman/SonicJS-API.postman_collection.json
+tests/postman/SonicJS-API.postman_environment.json
+```
+
+</CodeGroup>
+
+1. **Import into Postman**: Open Postman and import both files
+2. **Start the server**: Run `npm run dev`
+3. **Seed admin user**: Run the "Seed Admin User" request first
+4. **Start testing**: Authentication is handled automatically
+
+### Features
+
+<FeatureGrid
+  features={[
+    {
+      icon: '🔐',
+      title: 'Auto-Authentication',
+      description: 'Automatically logs in and refreshes tokens when needed',
+    },
+    {
+      icon: '📦',
+      title: 'Full API Coverage',
+      description: 'All endpoints including auth, content, media, users, and plugins',
+    },
+    {
+      icon: '🔑',
+      title: 'OTP Testing',
+      description: 'Test passwordless authentication with one-time codes',
+    },
+    {
+      icon: '⚡',
+      title: 'Collection Variables',
+      description: 'IDs and tokens are auto-saved for subsequent requests',
+    },
+  ]}
+  columns={4}
+/>
+
+### Endpoint Categories
+
+The collection includes these endpoint groups:
+
+| Category | Description |
+|----------|-------------|
+| **Public API** | Health checks, content listing, collection info |
+| **System API** | Health, stats, ping, environment info |
+| **Authentication** | Login, register, logout, password reset |
+| **OTP Authentication** | Request, verify, and resend one-time codes |
+| **Admin - Users** | CRUD operations, invitations, status toggle |
+| **Admin - Profile** | Profile management, password change, avatar |
+| **Admin - Content** | CRUD, versions, bulk actions, duplicate |
+| **Admin - Media** | Upload, folders, bulk operations, metadata |
+| **Admin - Plugins** | List, activate, deactivate, configure |
+| **Admin - Settings** | Migrations, database tools, general settings |
+| **Admin - Activity Logs** | View and export activity logs |
+
+### OTP Testing
+
+The collection includes endpoints for testing passwordless (OTP) authentication:
+
+<CodeGroup title="OTP Flow">
+
+```bash
+# 1. Request OTP code
+POST /auth/otp/request
+{ "email": "user@example.com" }
+
+# In development mode, the code is returned in the response
+# and auto-saved to the otpCode collection variable
+
+# 2. Verify OTP code
+POST /auth/otp/verify
+{ "email": "user@example.com", "code": "123456" }
+
+# On success, the auth token is saved automatically
+```
+
+</CodeGroup>
+
+<Callout type="tip" title="Development Mode">
+In development mode, the OTP code is returned directly in the API response (`dev_code` field) and automatically saved to the collection variable for easy testing.
+</Callout>
+
+### Default Credentials
+
+| Variable | Value | Description |
+|----------|-------|-------------|
+| `baseUrl` | `http://localhost:8787` | Local development server |
+| `testUserEmail` | `admin@sonicjs.com` | Default admin email |
+| `testUserPassword` | `sonicjs!` | Default admin password |
 
 ---
 


### PR DESCRIPTION
## Summary

- Updated all existing API endpoints in the Postman collection to match current route structure
- Added OTP (passwordless) Authentication endpoints for testing one-time codes
- Added System API endpoints (health, info, stats, ping, env)
- Added Admin Profile, Activity Logs, and Dashboard API endpoints
- Updated auto-authentication to skip OTP and system endpoints
- Updated default credentials to `admin@sonicjs.com` / `sonicjs!`
- Added comprehensive documentation to the www Testing page

## Changes

### Postman Collection (`tests/postman/`)
- **New: OTP Authentication folder** with Request, Verify, and Resend OTP endpoints
- **New: System API folder** with health, info, stats, ping, and env endpoints
- **New: Admin Profile folder** with profile, password, and avatar management
- **New: Admin Activity Logs folder** with view and export endpoints
- **New: Admin Dashboard API folder** with stats, storage, and activity endpoints
- Updated pre-request script to handle OTP testing with auto-saved codes
- Added `otpEmail` and `otpCode` collection variables
- Updated environment file with current default credentials

### Documentation (`www/src/app/testing/page.mdx`)
- Added "Manual API Testing with Postman" section
- Added Postman to the Testing Stack overview
- Documented all endpoint categories
- Added OTP testing workflow examples
- Updated metadata description

## Test plan
- [ ] Import the Postman collection and environment into Postman
- [ ] Start local dev server with `npm run dev`
- [ ] Run "Seed Admin User" request
- [ ] Test OTP flow: Request OTP → Verify OTP
- [ ] Verify auto-authentication works on protected endpoints
- [ ] Check www Testing page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)