### PR TITLE
fix(core): enable EasyMDE data sync 

### DIFF
--- a/packages/core/src/plugins/available/easy-mdx/index.ts
+++ b/packages/core/src/plugins/available/easy-mdx/index.ts
@@ -209,6 +209,13 @@ export function getMDXEditorInitScript(config?: {
           // Store reference to editor instance
           textarea.easyMDEInstance = easyMDE;
 
+          // Sync changes back to textarea
+          easyMDE.codemirror.on("change", () => {
+            textarea.value = easyMDE.value();
+            textarea.dispatchEvent(new Event("input", { bubbles: true }));
+            textarea.dispatchEvent(new Event("change", { bubbles: true }));
+          });
+
           console.log('EasyMDE initialized for field:', textarea.id || textarea.name);
         } catch (error) {
           console.error('Error initializing EasyMDE:', error);


### PR DESCRIPTION
The EasyMDE editor content was not syncing back to the textarea (causing data not saved).

## Description
Fixed an issue where EasyMDE content was not syncing back to the textarea (causing save failures).

## Changes
packages/core/src/plugins/available/easy-mdx/index.ts
A change event listener has been added to ensure that changes to EasyMDE's content are synchronized back to the underlying textarea in real time.

## Testing
Functional testing was passed on the local project.
1. npm pack 
2. npm install "..\sonicjs\packages\core\sonicjs-cms-core-2.3.13.tgz"
3. Testing the content update function.