### PR TITLE
fix(www): enable static assets incremental cache for blog posts

### DIFF
--- a/www/open-next.config.ts
+++ b/www/open-next.config.ts
@@ -1,5 +1,8 @@
 import { defineCloudflareConfig } from "@opennextjs/cloudflare";
+import staticAssetsIncrementalCache from "@opennextjs/cloudflare/overrides/incremental-cache/static-assets-incremental-cache";
 
 export default defineCloudflareConfig({
-  // Use default configuration
+  // Use static assets cache for prerendered blog posts and pages
+  incrementalCache: staticAssetsIncrementalCache,
+  enableCacheInterception: true,
 });


### PR DESCRIPTION
## Summary
- Configures OpenNext to use `staticAssetsIncrementalCache` for serving prerendered blog posts
- Enables `enableCacheInterception` for proper cache handling
- Fixes issue where blog listing page showed "No blog posts yet" despite posts being built

## Problem
The blog page at https://sonicjs.com/blog was showing "No blog posts yet" even though the build logs confirmed 5 blog posts were being generated at build time. The issue was that OpenNext was using the default cache configuration which doesn't serve prerendered static pages properly on Cloudflare Workers.

## Solution
Configure OpenNext to use the static assets incremental cache, which serves build-time prerendered values from Workers Static Assets. This is the recommended approach for SSG (Static Site Generation) sites according to the [OpenNext documentation](https://opennext.js.org/cloudflare/caching).

## Test plan
- [x] Verified `npm run build` succeeds with the new configuration
- [x] Verified `opennextjs-cloudflare build` completes successfully
- [ ] After merge, verify https://sonicjs.com/blog shows the blog posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)