### PR TITLE
fix(dev): wait for core dist build before starting wrangler

### DIFF
--- a/my-sonicjs-app/package.json
+++ b/my-sonicjs-app/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "dev": "npm run dev:build && npm run dev:watch",
     "dev:build": "cd ../packages/core && npm run build",
-    "dev:watch": "npm run dev:core & wrangler dev 2>&1 | grep -v '\\[wrangler:inf\\]'",
+    "dev:watch": "npm run dev:core & npx wait-on ../packages/core/dist/index.js && wrangler dev 2>&1 | grep -v '\\[wrangler:inf\\]'",
     "dev:core": "cd ../packages/core && npm run dev",
     "build": "echo 'Worker build is handled by wrangler during deployment'",
     "deploy": "wrangler deploy",


### PR DESCRIPTION


## Description
Use wait-on in dev:watch to avoid race between tsup --watch and wrangler dev

Fixes #455

## Changes
- Use wait-on in dev:watch to avoid race between tsup --watch and wrangler dev
- Prevents 'Could not resolve "@sonicjs-cms/core"' during startup

## Testing
Just running the dev command. `npm run dev`

### Unit Tests
- [ ] Added/updated unit tests
- [ ] All unit tests passing

### E2E Tests
- [ ] Added/updated E2E tests
- [ ] All E2E tests passing

## Screenshots/Videos

## Checklist
- [x] Code follows project conventions
- [ ] Tests added/updated and passing
- [x] Type checking passes
- [x] No console errors or warnings
- [ ] Documentation updated (if needed)

---
Generated with Claude Code in Conductor
