### PR TITLE
test: unskip EasyMDE/MDXEditor e2e tests

### DIFF
--- a/tests/e2e/32-mdxeditor-new-content.spec.ts
+++ b/tests/e2e/32-mdxeditor-new-content.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test'
 import { loginAsAdmin } from './utils/test-helpers'
 
-test.describe.skip('MDXEditor on New Content Form', () => {
+test.describe('MDXEditor on New Content Form', () => {
   test.beforeEach(async ({ page }) => {
     await loginAsAdmin(page)
   })

--- a/tests/e2e/32-mdxeditor-richtext.spec.ts
+++ b/tests/e2e/32-mdxeditor-richtext.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test';
 import { loginAsAdmin, navigateToAdminSection, waitForHTMX } from './utils/test-helpers';
 
-test.describe.skip('MDXEditor Rich Text Editor', () => {
+test.describe('MDXEditor Rich Text Editor', () => {
   test.beforeEach(async ({ page }) => {
     await loginAsAdmin(page);
   });

--- a/tests/e2e/36-collection-field-easymdx-edit.spec.ts
+++ b/tests/e2e/36-collection-field-easymdx-edit.spec.ts
@@ -4,7 +4,7 @@ import { loginAsAdmin, ensureAdminUserExists } from './utils/test-helpers';
 // Use environment variable for port or default to 8787
 const BASE_URL = process.env.BASE_URL || 'http://localhost:8787';
 
-test.describe.skip('Collection Field EasyMDX Edit', () => {
+test.describe('Collection Field EasyMDX Edit', () => {
   test.beforeEach(async ({ page }) => {
     await ensureAdminUserExists(page);
     await loginAsAdmin(page);

--- a/tests/e2e/36-easymde-plugin-visible.spec.ts
+++ b/tests/e2e/36-easymde-plugin-visible.spec.ts
@@ -1,7 +1,7 @@
 import { test, expect } from '@playwright/test'
 import { loginAsAdmin } from './utils/test-helpers'
 
-test.describe.skip('EasyMDE Plugin Visibility', () => {
+test.describe('EasyMDE Plugin Visibility', () => {
   test.beforeEach(async ({ page }) => {
     await loginAsAdmin(page)
   })


### PR DESCRIPTION
## Summary
- Unskips the EasyMDE/MDXEditor e2e tests that were previously skipped
- These tests verify the EasyMDE markdown editor plugin functionality

## Test plan
- [ ] Run e2e tests locally to verify tests pass
- [ ] CI should run the unskipped tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)