### PR TITLE
feat: add environment protection for fork PR testing

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,7 +1,7 @@
 name: PR Tests
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
   push:
@@ -9,13 +9,32 @@ on:
       - main
 
 jobs:
+  # Authorization job - gates fork PRs behind environment approval
+  authorize:
+    runs-on: ubuntu-latest
+    # Use 'external' environment (requires approval) for fork PRs, 'internal' for same-repo PRs
+    environment:
+      name: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository && 'external' || 'internal' }}
+    steps:
+      - name: Authorize
+        run: |
+          echo "✅ Workflow authorized"
+          echo "Event: ${{ github.event_name }}"
+          echo "Repository: ${{ github.repository }}"
+          echo "PR Head Repo: ${{ github.event.pull_request.head.repo.full_name || 'N/A' }}"
+          echo "Is Fork: ${{ github.event.pull_request.head.repo.full_name != github.repository }}"
+
   test:
+    needs: authorize
     runs-on: ubuntu-latest
     timeout-minutes: 60
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # For pull_request_target, we need to checkout the PR head
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## Summary
- Changed from `pull_request` to `pull_request_target` trigger for PR tests workflow
- Added `authorize` job that uses `external` environment for fork PRs (requires manual approval)
- Same-repo PRs use `internal` environment (auto-approved, no delay)
- Properly checkout PR head SHA for `pull_request_target` events

## Why
Fork PRs don't have access to repository secrets by default (security feature). This change allows maintainers to:
1. Review the fork PR code first
2. Approve the workflow run in GitHub Actions
3. Run E2E tests with Cloudflare secrets

## Setup Required
After merging, create two GitHub Environments:

1. **`external`** - Settings → Environments → New environment
   - Enable "Required reviewers"
   - Add maintainers as reviewers

2. **`internal`** - Settings → Environments → New environment
   - No protection rules needed

## How it works

| PR Source | Environment | Behavior |
|-----------|-------------|----------|
| Fork | `external` | Pauses for approval |
| Same repo | `internal` | Runs immediately |
| Dependabot | N/A | Skips E2E (unit tests only) |

## Also includes
- Sticky sidebar plugins layout changes from PR #457 by @lassespilling

🤖 Generated with [Claude Code](https://claude.com/claude-code)