### PR TITLE
Remove any from plugin manifest #435

### DIFF
--- a/packages/core/src/types/plugin-manifest.ts
+++ b/packages/core/src/types/plugin-manifest.ts
@@ -4,7 +4,9 @@
  * Defines the structure for plugin manifest.json files
  */
 
-export interface PluginManifest {
+export interface PluginManifest<
+  Settings extends Record<string, unknown> = Record<string, unknown>
+> {
   id: string
   name: string
   version: string
@@ -16,7 +18,7 @@ export interface PluginManifest {
   category: string
   tags?: string[]
   dependencies?: string[]
-  settings?: Record<string, any>
+  settings?: Settings
   hooks?: Record<string, string>
   routes?: Array<{
     path: string


### PR DESCRIPTION
## Description
I chose a small one for my first PR, if this looks good I’ll tackle more from https://github.com/lane711/sonicjs/issues/435. Replace `any` in plugin manifest settings with a generic `Settings` type defaulting to `Record<string, unknown>`.

Fixes # [435](https://github.com/lane711/sonicjs/issues/435)

## Changes
- Make `PluginManifest` generic over settings type
- Replace `Record<string, any>` with a safe generic default

## Testing
`npm run type-check`

### Unit Tests
- [ ] Added/updated unit tests
- [ ] All unit tests passing

### E2E Tests
- [ ] Added/updated E2E tests
- [ ] All E2E tests passing

## Checklist
- [x] Code follows project conventions
- [ ] Tests added/updated and passing
- [x] Type checking passes
- [x] No console errors or warnings
- [ ] Documentation updated (if needed)

---
Generated with Claude Code in Conductor
