### PR TITLE
fix(seed-data): mount plugin routes and auto-seed admin user

### DIFF
--- a/my-sonicjs-app/scripts/setup-worktree-db.sh
+++ b/my-sonicjs-app/scripts/setup-worktree-db.sh
@@ -97,12 +97,18 @@ echo ""
 echo "Running migrations on local database..."
 npx wrangler d1 migrations apply "$DB_NAME" --local
 
+# Seed admin user
+echo ""
+echo "Seeding admin user..."
+npx tsx scripts/seed-admin.ts
+
 echo ""
 echo "=========================================="
 echo "Database setup complete!"
 echo "Database name: $DB_NAME"
 echo "Database ID: $DB_ID"
 echo "Both remote and local databases are ready."
+echo "Admin user: admin@sonicjs.com / sonicjs!"
 echo "=========================================="
 echo ""
 echo "You can now run: npm run dev"

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -27,6 +27,7 @@ import { getCoreVersion } from './utils/version'
 import { bootstrapMiddleware } from './middleware/bootstrap'
 import { metricsMiddleware } from './middleware/metrics'
 import { createDatabaseToolsAdminRoutes } from './plugins/core-plugins/database-tools-plugin/admin-routes'
+import { createSeedDataAdminRoutes } from './plugins/core-plugins/seed-data-plugin/admin-routes'
 import { emailPlugin } from './plugins/core-plugins/email-plugin'
 import { otpLoginPlugin } from './plugins/core-plugins/otp-login-plugin'
 import { createMagicLinkAuthPlugin } from './plugins/available/magic-link-auth'
@@ -179,6 +180,7 @@ export function createSonicJSApp(config: SonicJSConfig = {}): SonicJSApp {
   app.route('/admin/collections', adminCollectionsRoutes)
   app.route('/admin/settings', adminSettingsRoutes)
   app.route('/admin/database-tools', createDatabaseToolsAdminRoutes())
+  app.route('/admin/seed-data', createSeedDataAdminRoutes())
   app.route('/admin/content', adminContentRoutes)
   app.route('/admin/media', adminMediaRoutes)
   app.route('/admin/plugins', adminPluginRoutes)

--- a/packages/core/src/plugins/core-plugins/seed-data-plugin/admin-routes.ts
+++ b/packages/core/src/plugins/core-plugins/seed-data-plugin/admin-routes.ts
@@ -116,10 +116,21 @@ export function createSeedDataAdminRoutes() {
               display: none;
               margin-left: 1rem;
             }
+            .back-link {
+              display: inline-block;
+              margin-bottom: 1rem;
+              color: #3b82f6;
+              text-decoration: none;
+              font-size: 0.9rem;
+            }
+            .back-link:hover {
+              text-decoration: underline;
+            }
           </style>
         </head>
         <body>
           <div class="container">
+            <a href="/admin/plugins/seed-data" class="back-link">← Back to Plugin Settings</a>
             <h1>🌱 Seed Data Generator</h1>
             <p class="description">
               Generate realistic example data for testing and development. This will create 20 users and 200 content items with realistic data.


### PR DESCRIPTION
## Summary
- Mount seed-data plugin routes at `/admin/seed-data` in app.ts (fixes 404 error when accessing the seed data tool)
- Auto-seed admin user in `setup-worktree-db.sh` after migrations run
- Fix password hashing in `seed-admin.ts` to use Web Crypto API (matching AuthManager)
- Add back link to plugin settings on seed data generator page

## Test plan
- [ ] Run `npm run workspace` and verify admin user is seeded automatically
- [ ] Login with `admin@sonicjs.com` / `sonicjs!`
- [ ] Navigate to `/admin/seed-data` and verify no 404
- [ ] Verify back link navigates to `/admin/plugins/seed-data`

🤖 Generated with [Claude Code](https://claude.com/claude-code)