### PR TITLE
fix(www): update GitHub stars count to accurate 1.4K+

### DIFF
--- a/www/src/app/community/page.mdx
+++ b/www/src/app/community/page.mdx
@@ -38,7 +38,7 @@ The SonicJS community is a welcoming space for developers of all skill levels. W
     },
     {
       icon: '⭐',
-      title: '2.5K+ Stars',
+      title: '1.4K+ Stars',
       description: 'GitHub stars and growing',
     },
     {


### PR DESCRIPTION
## Summary
- Updated the community page GitHub stars count from 2.5K+ to 1.4K+ to reflect the actual count (1,356 stars)

## Test plan
- [ ] Verify the community page displays the updated stars count

🤖 Generated with [Claude Code](https://claude.com/claude-code)