### PR TITLE
Add GitHub Sponsors integration and sponsor page

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+github: lane711

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A modern, TypeScript-first headless CMS built for Cloudflare's edge platform wit
 
 **[sonicjs.com](https://sonicjs.com)**
 
+[![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-pink?style=for-the-badge&logo=github-sponsors)](https://github.com/sponsors/lane711)
+
 > **📦 Get Started:** `npx create-sonicjs@latest my-app`
 >
 > **⚠️ Note:** This repository is for **developing the SonicJS core package**. To build an application with SonicJS, use the command above to create a new project.
@@ -358,6 +360,18 @@ MIT License - see [LICENSE](LICENSE) file for details.
 ## 🤝 Contributing
 
 We welcome contributions! Please see our contributing guidelines for more details.
+
+## ❤️ Sponsor
+
+SonicJS is 100% open source and free forever. If you find it useful, please consider sponsoring to support continued development:
+
+[![Sponsor on GitHub](https://img.shields.io/badge/Sponsor_on_GitHub-%E2%9D%A4-pink?style=for-the-badge&logo=github-sponsors)](https://github.com/sponsors/lane711)
+
+Your sponsorship helps fund:
+- 🚀 New features and improvements
+- 📚 Documentation and tutorials
+- 🐛 Bug fixes and maintenance
+- 💬 Community support
 
 ## 📞 Support
 

--- a/www/src/app/page.mdx
+++ b/www/src/app/page.mdx
@@ -51,6 +51,15 @@ export const metadata = {
         <span className="transform transition-transform duration-300 group-hover:translate-x-1 group-hover:-translate-y-1">↗️</span>
       </span>
     </a>
+    <a
+      href="https://github.com/sponsors/lane711"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group inline-flex items-center gap-2 px-6 py-3 text-white font-semibold rounded-lg bg-gradient-to-r from-pink-500 to-rose-500 hover:from-pink-600 hover:to-rose-600 transition-all duration-300 hover:scale-105 hover:shadow-xl"
+    >
+      <span className="text-lg">❤️</span>
+      <span>Sponsor</span>
+    </a>
   </div>
 </div>
 

--- a/www/src/app/sponsor/page.mdx
+++ b/www/src/app/sponsor/page.mdx
@@ -1,0 +1,349 @@
+export const metadata = {
+  title: 'Sponsor SonicJS - Support the World\'s Fastest Headless CMS',
+  description:
+    'Support SonicJS development through GitHub Sponsors. Help keep the world\'s fastest headless CMS free and actively maintained.',
+}
+
+export const sections = [
+  { title: 'Why Sponsor?', id: 'why-sponsor' },
+  { title: 'Sponsorship Tiers', id: 'sponsorship-tiers' },
+  { title: 'How Funds Are Used', id: 'how-funds-are-used' },
+  { title: 'Become a Sponsor', id: 'become-a-sponsor' },
+  { title: 'Our Sponsors', id: 'our-sponsors' },
+]
+
+# Sponsor SonicJS
+
+Help support the development of the world's fastest headless CMS. Your sponsorship keeps SonicJS free, open source, and actively maintained. {{ className: 'lead' }}
+
+---
+
+## Why Sponsor?
+
+SonicJS is **100% open source** and **free forever** under the MIT license. Building and maintaining a production-ready CMS takes significant time and effort. Your sponsorship directly supports:
+
+<FeatureGrid
+  features={[
+    {
+      icon: '🚀',
+      title: 'Continued Development',
+      description: 'New features, performance improvements, and bug fixes',
+    },
+    {
+      icon: '📚',
+      title: 'Documentation',
+      description: 'Tutorials, guides, and examples to help developers succeed',
+    },
+    {
+      icon: '💬',
+      title: 'Community Support',
+      description: 'Answering questions, reviewing PRs, helping users',
+    },
+    {
+      icon: '🔧',
+      title: 'Infrastructure',
+      description: 'Demo sites, testing environments, and CI/CD',
+    },
+  ]}
+  columns={2}
+/>
+
+### What Makes SonicJS Special
+
+SonicJS delivers **6x faster performance** than traditional Node/Express solutions with **sub-100ms response times globally**. Built specifically for Cloudflare's edge network, it runs in 300+ data centers worldwide with zero cold starts.
+
+<div className="not-prose my-8 p-6 rounded-lg bg-gradient-to-r from-emerald-50 to-teal-50 dark:from-emerald-950/30 dark:to-teal-950/30 border border-emerald-200 dark:border-emerald-800">
+  <div className="flex items-center gap-4 mb-4">
+    <div className="text-4xl">⚡</div>
+    <div>
+      <h3 className="text-xl font-bold text-emerald-900 dark:text-emerald-100 m-0">The World's Fastest Headless CMS</h3>
+      <p className="text-emerald-700 dark:text-emerald-300 m-0">Built on Cloudflare Workers for unmatched performance</p>
+    </div>
+  </div>
+  <div className="grid grid-cols-3 gap-4 text-center">
+    <div>
+      <div className="text-2xl font-bold text-emerald-600 dark:text-emerald-400">6x</div>
+      <div className="text-sm text-emerald-700 dark:text-emerald-300">Faster than Node</div>
+    </div>
+    <div>
+      <div className="text-2xl font-bold text-emerald-600 dark:text-emerald-400">&lt;100ms</div>
+      <div className="text-sm text-emerald-700 dark:text-emerald-300">Response time</div>
+    </div>
+    <div>
+      <div className="text-2xl font-bold text-emerald-600 dark:text-emerald-400">300+</div>
+      <div className="text-sm text-emerald-700 dark:text-emerald-300">Edge locations</div>
+    </div>
+  </div>
+</div>
+
+---
+
+## Sponsorship Tiers
+
+Choose a sponsorship tier that works for you. Every contribution, no matter the size, helps keep SonicJS thriving.
+
+<div className="not-prose">
+  <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3 my-8">
+
+    <div className="flex flex-col rounded-xl border-2 border-zinc-200 dark:border-zinc-700 p-6 hover:border-zinc-300 dark:hover:border-zinc-600 transition">
+      <div className="text-3xl mb-3">☕</div>
+      <h3 className="text-lg font-bold mb-1 m-0">Supporter</h3>
+      <div className="text-2xl font-bold text-zinc-900 dark:text-white mb-2">$5<span className="text-sm font-normal text-zinc-500">/month</span></div>
+      <ul className="text-sm text-zinc-600 dark:text-zinc-400 space-y-2 mb-4 flex-1">
+        <li className="flex items-start gap-2">
+          <span className="text-emerald-500">✓</span>
+          <span>Name listed in README supporters section</span>
+        </li>
+        <li className="flex items-start gap-2">
+          <span className="text-emerald-500">✓</span>
+          <span>Supporter Discord role</span>
+        </li>
+        <li className="flex items-start gap-2">
+          <span className="text-emerald-500">✓</span>
+          <span>Our eternal gratitude</span>
+        </li>
+      </ul>
+    </div>
+
+    <div className="flex flex-col rounded-xl border-2 border-zinc-200 dark:border-zinc-700 p-6 hover:border-zinc-300 dark:hover:border-zinc-600 transition">
+      <div className="text-3xl mb-3">🥉</div>
+      <h3 className="text-lg font-bold mb-1 m-0">Bronze Sponsor</h3>
+      <div className="text-2xl font-bold text-zinc-900 dark:text-white mb-2">$25<span className="text-sm font-normal text-zinc-500">/month</span></div>
+      <ul className="text-sm text-zinc-600 dark:text-zinc-400 space-y-2 mb-4 flex-1">
+        <li className="flex items-start gap-2">
+          <span className="text-emerald-500">✓</span>
+          <span>Everything in Supporter tier</span>
+        </li>
+        <li className="flex items-start gap-2">
+          <span className="text-emerald-500">✓</span>
+          <span>Logo in README sponsors section</span>
+        </li>
+        <li className="flex items-start gap-2">
+          <span className="text-emerald-500">✓</span>
+          <span>Bronze sponsor Discord role</span>
+        </li>
+      </ul>
+    </div>
+
+    <div className="flex flex-col rounded-xl border-2 border-emerald-500 dark:border-emerald-600 p-6 relative">
+      <div className="absolute -top-3 left-1/2 -translate-x-1/2 bg-emerald-500 text-white text-xs font-bold px-3 py-1 rounded-full">POPULAR</div>
+      <div className="text-3xl mb-3">🥈</div>
+      <h3 className="text-lg font-bold mb-1 m-0">Silver Sponsor</h3>
+      <div className="text-2xl font-bold text-zinc-900 dark:text-white mb-2">$100<span className="text-sm font-normal text-zinc-500">/month</span></div>
+      <ul className="text-sm text-zinc-600 dark:text-zinc-400 space-y-2 mb-4 flex-1">
+        <li className="flex items-start gap-2">
+          <span className="text-emerald-500">✓</span>
+          <span>Everything in Bronze tier</span>
+        </li>
+        <li className="flex items-start gap-2">
+          <span className="text-emerald-500">✓</span>
+          <span>Logo on SonicJS.com sponsors page</span>
+        </li>
+        <li className="flex items-start gap-2">
+          <span className="text-emerald-500">✓</span>
+          <span>Priority GitHub issue support</span>
+        </li>
+        <li className="flex items-start gap-2">
+          <span className="text-emerald-500">✓</span>
+          <span>Monthly office hours access</span>
+        </li>
+      </ul>
+    </div>
+
+    <div className="flex flex-col rounded-xl border-2 border-amber-400 dark:border-amber-500 p-6 bg-gradient-to-b from-amber-50/50 to-transparent dark:from-amber-950/20">
+      <div className="text-3xl mb-3">🥇</div>
+      <h3 className="text-lg font-bold mb-1 m-0">Gold Sponsor</h3>
+      <div className="text-2xl font-bold text-zinc-900 dark:text-white mb-2">$250<span className="text-sm font-normal text-zinc-500">/month</span></div>
+      <ul className="text-sm text-zinc-600 dark:text-zinc-400 space-y-2 mb-4 flex-1">
+        <li className="flex items-start gap-2">
+          <span className="text-emerald-500">✓</span>
+          <span>Everything in Silver tier</span>
+        </li>
+        <li className="flex items-start gap-2">
+          <span className="text-emerald-500">✓</span>
+          <span>Prominent logo on homepage</span>
+        </li>
+        <li className="flex items-start gap-2">
+          <span className="text-emerald-500">✓</span>
+          <span>Featured in release announcements</span>
+        </li>
+        <li className="flex items-start gap-2">
+          <span className="text-emerald-500">✓</span>
+          <span>Direct Slack/Discord channel</span>
+        </li>
+      </ul>
+    </div>
+
+    <div className="flex flex-col rounded-xl border-2 border-purple-400 dark:border-purple-500 p-6 bg-gradient-to-b from-purple-50/50 to-transparent dark:from-purple-950/20 md:col-span-2 lg:col-span-2">
+      <div className="text-3xl mb-3">💎</div>
+      <h3 className="text-lg font-bold mb-1 m-0">Platinum Sponsor</h3>
+      <div className="text-2xl font-bold text-zinc-900 dark:text-white mb-2">$500+<span className="text-sm font-normal text-zinc-500">/month</span></div>
+      <div className="grid md:grid-cols-2 gap-4">
+        <ul className="text-sm text-zinc-600 dark:text-zinc-400 space-y-2 mb-4">
+          <li className="flex items-start gap-2">
+            <span className="text-emerald-500">✓</span>
+            <span>Everything in Gold tier</span>
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="text-emerald-500">✓</span>
+            <span>Logo at top of README</span>
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="text-emerald-500">✓</span>
+            <span>Featured case study on blog</span>
+          </li>
+        </ul>
+        <ul className="text-sm text-zinc-600 dark:text-zinc-400 space-y-2 mb-4">
+          <li className="flex items-start gap-2">
+            <span className="text-emerald-500">✓</span>
+            <span>Quarterly strategy calls</span>
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="text-emerald-500">✓</span>
+            <span>Input on roadmap priorities</span>
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="text-emerald-500">✓</span>
+            <span>Early access to new features</span>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+  </div>
+</div>
+
+### One-Time Contributions
+
+Not ready for monthly sponsorship? One-time contributions are also welcome and appreciated!
+
+---
+
+## How Funds Are Used
+
+We believe in transparency. Here's how sponsorship funds are allocated:
+
+<div className="not-prose my-8">
+  <div className="space-y-4">
+    <div className="flex items-center gap-4">
+      <div className="w-full bg-zinc-200 dark:bg-zinc-700 rounded-full h-6 overflow-hidden">
+        <div className="bg-emerald-500 h-full rounded-full flex items-center justify-end pr-2" style={{width: '50%'}}>
+          <span className="text-xs font-bold text-white">50%</span>
+        </div>
+      </div>
+      <span className="text-sm font-medium whitespace-nowrap w-40">Core Development</span>
+    </div>
+    <div className="flex items-center gap-4">
+      <div className="w-full bg-zinc-200 dark:bg-zinc-700 rounded-full h-6 overflow-hidden">
+        <div className="bg-blue-500 h-full rounded-full flex items-center justify-end pr-2" style={{width: '20%'}}>
+          <span className="text-xs font-bold text-white">20%</span>
+        </div>
+      </div>
+      <span className="text-sm font-medium whitespace-nowrap w-40">Documentation</span>
+    </div>
+    <div className="flex items-center gap-4">
+      <div className="w-full bg-zinc-200 dark:bg-zinc-700 rounded-full h-6 overflow-hidden">
+        <div className="bg-purple-500 h-full rounded-full flex items-center justify-end pr-2" style={{width: '15%'}}>
+          <span className="text-xs font-bold text-white">15%</span>
+        </div>
+      </div>
+      <span className="text-sm font-medium whitespace-nowrap w-40">Community Support</span>
+    </div>
+    <div className="flex items-center gap-4">
+      <div className="w-full bg-zinc-200 dark:bg-zinc-700 rounded-full h-6 overflow-hidden">
+        <div className="bg-amber-500 h-full rounded-full flex items-center justify-end pr-2" style={{width: '15%'}}>
+          <span className="text-xs font-bold text-white">15%</span>
+        </div>
+      </div>
+      <span className="text-sm font-medium whitespace-nowrap w-40">Infrastructure</span>
+    </div>
+  </div>
+</div>
+
+---
+
+## Become a Sponsor
+
+Ready to support SonicJS? Choose your preferred platform:
+
+<div className="not-prose my-8">
+  <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+    <a
+      href="https://github.com/sponsors/lane711"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-center gap-4 rounded-xl border-2 border-zinc-200 dark:border-zinc-700 p-6 hover:border-pink-500 dark:hover:border-pink-500 transition group"
+    >
+      <div className="text-4xl">❤️</div>
+      <div>
+        <h3 className="text-lg font-bold m-0 group-hover:text-pink-600 dark:group-hover:text-pink-400 transition">GitHub Sponsors</h3>
+        <p className="text-sm text-zinc-600 dark:text-zinc-400 m-0">Sponsor directly through GitHub</p>
+      </div>
+      <svg className="w-5 h-5 ml-auto text-zinc-400 group-hover:text-pink-500 transition" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+      </svg>
+    </a>
+  </div>
+</div>
+
+### For Businesses
+
+If your company uses SonicJS in production, consider becoming a corporate sponsor. Benefits include:
+
+- **Brand visibility** to thousands of developers
+- **Direct support channel** for faster issue resolution
+- **Input on roadmap** to prioritize features you need
+- **Tax deductible** in many jurisdictions
+
+Contact **lane@sonicjs.com** for custom sponsorship arrangements.
+
+---
+
+## Our Sponsors
+
+A huge thank you to all our sponsors who make SonicJS possible!
+
+### Platinum Sponsors
+
+<div className="not-prose my-6 p-8 rounded-xl border-2 border-dashed border-zinc-300 dark:border-zinc-700 text-center">
+  <p className="text-zinc-500 dark:text-zinc-400 m-0">Your logo here</p>
+  <a href="https://github.com/sponsors/lane711" className="text-sm text-emerald-600 hover:text-emerald-700 dark:text-emerald-400">Become a Platinum Sponsor →</a>
+</div>
+
+### Gold Sponsors
+
+<div className="not-prose my-6 p-8 rounded-xl border-2 border-dashed border-zinc-300 dark:border-zinc-700 text-center">
+  <p className="text-zinc-500 dark:text-zinc-400 m-0">Your logo here</p>
+  <a href="https://github.com/sponsors/lane711" className="text-sm text-emerald-600 hover:text-emerald-700 dark:text-emerald-400">Become a Gold Sponsor →</a>
+</div>
+
+### Silver Sponsors
+
+<div className="not-prose my-6 p-6 rounded-xl border-2 border-dashed border-zinc-300 dark:border-zinc-700 text-center">
+  <p className="text-zinc-500 dark:text-zinc-400 m-0">Your logo here</p>
+  <a href="https://github.com/sponsors/lane711" className="text-sm text-emerald-600 hover:text-emerald-700 dark:text-emerald-400">Become a Silver Sponsor →</a>
+</div>
+
+### Bronze Sponsors & Supporters
+
+<div className="not-prose my-6 p-6 rounded-xl border-2 border-dashed border-zinc-300 dark:border-zinc-700 text-center">
+  <p className="text-zinc-500 dark:text-zinc-400 m-0">Be the first to support SonicJS!</p>
+  <a href="https://github.com/sponsors/lane711" className="text-sm text-emerald-600 hover:text-emerald-700 dark:text-emerald-400">Become a Sponsor →</a>
+</div>
+
+---
+
+## Thank You
+
+Whether you sponsor, contribute code, write documentation, or just use SonicJS - thank you for being part of this community. Every contribution matters.
+
+<div className="not-prose mt-8">
+  <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+    <Button href="https://github.com/sponsors/lane711" variant="primary">
+      <>❤️ Sponsor on GitHub</>
+    </Button>
+    <Button href="/community" variant="secondary">
+      <>Join the Community</>
+    </Button>
+  </div>
+</div>

--- a/www/src/components/Navigation.tsx
+++ b/www/src/components/Navigation.tsx
@@ -282,6 +282,7 @@ export const navigation: Array<NavGroup> = [
       { title: 'FAQ', href: '/faq' },
       { title: 'Changelog', href: '/changelog' },
       { title: 'Community', href: '/community' },
+      { title: 'Sponsor', href: '/sponsor' },
       { title: 'Contributing', href: '/contributing' },
       { title: 'Coding Standards', href: '/coding-standards' },
       { title: 'Telemetry', href: '/telemetry' },


### PR DESCRIPTION
## Summary

- Add dedicated sponsor page to website (`/sponsor`) with sponsorship tiers and benefits
- Add sponsor button to homepage hero section (pink heart button)
- Add sponsor badge and dedicated section to README
- Add `.github/FUNDING.yml` for GitHub sponsor button in repo sidebar
- Add sponsor link to site navigation

## Changes

- `www/src/app/sponsor/page.mdx` - New sponsor page with tiers, perks, and fund allocation breakdown
- `www/src/app/page.mdx` - Added sponsor button next to GitHub star button
- `www/src/components/Navigation.tsx` - Added sponsor link to Resources section
- `README.md` - Added sponsor badge at top and sponsor section at bottom
- `.github/FUNDING.yml` - Enables GitHub Sponsors button on repo

## Test plan

- [ ] Verify sponsor page renders correctly at `/sponsor`
- [ ] Verify sponsor button on homepage links to GitHub Sponsors
- [ ] Verify sponsor link appears in navigation
- [ ] Verify README badge renders correctly on GitHub
- [ ] Verify FUNDING.yml enables sponsor button on repo sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)