### PR TITLE
feat: add Deploy to Cloudflare button to README and homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A modern, TypeScript-first headless CMS built for Cloudflare's edge platform wit
 **[sonicjs.com](https://sonicjs.com)**
 
 [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-pink?style=for-the-badge&logo=github-sponsors)](https://github.com/sponsors/lane711)
+[![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/lane711/sonicjs-deploy-now)
 
 > **📦 Get Started:** `npx create-sonicjs@latest my-app`
 >

--- a/www/src/app/page.mdx
+++ b/www/src/app/page.mdx
@@ -60,6 +60,15 @@ export const metadata = {
       <span className="text-lg">❤️</span>
       <span>Sponsor</span>
     </a>
+    <a
+      href="https://deploy.workers.cloudflare.com/?url=https://github.com/lane711/sonicjs-deploy-now"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group inline-flex items-center gap-2 px-6 py-3 text-white font-semibold rounded-lg bg-gradient-to-r from-orange-500 to-amber-500 hover:from-orange-600 hover:to-amber-600 transition-all duration-300 hover:scale-105 hover:shadow-xl"
+    >
+      <span className="text-lg">☁️</span>
+      <span>Deploy to Cloudflare</span>
+    </a>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Adds "Deploy to Cloudflare" button badge to README.md
- Adds styled "Deploy to Cloudflare" button to website homepage hero section
- Links to the new [sonicjs-deploy-now](https://github.com/lane711/sonicjs-deploy-now) repo for one-click deployment

Closes #333

## Test plan
- [ ] Verify deploy button appears correctly in README
- [ ] Verify deploy button appears on homepage and links correctly
- [ ] Test the deploy flow via the sonicjs-deploy-now repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)