### PR TITLE
feat: add Codecov integration and dynamic test count badge

### DIFF
--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -50,8 +50,17 @@ jobs:
       # - name: Type check
       #   run: npm run type-check
 
-      - name: Run unit tests
-        run: npm test
+      - name: Run unit tests with coverage
+        run: npm run test:cov
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./packages/core/coverage/coverage-final.json
+          flags: unittests
+          fail_ci_if_error: false
+          verbose: true
 
       - name: Build core package
         run: npm run build:core

--- a/.github/workflows/update-badges.yml
+++ b/.github/workflows/update-badges.yml
@@ -1,0 +1,56 @@
+name: Update Badges
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  update-test-count-badge:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Count tests
+        id: count-tests
+        run: |
+          # Count unit tests (it/test calls in test files)
+          UNIT_TESTS=$(grep -rE "(it|test)\(" --include="*.test.ts" --include="*.spec.ts" packages/ 2>/dev/null | wc -l | tr -d ' ')
+
+          # Count e2e tests
+          E2E_TESTS=$(grep -rE "(it|test)\(" --include="*.spec.ts" tests/e2e/ 2>/dev/null | wc -l | tr -d ' ')
+
+          # Total tests
+          TOTAL_TESTS=$((UNIT_TESTS + E2E_TESTS))
+
+          echo "Unit tests: $UNIT_TESTS"
+          echo "E2E tests: $E2E_TESTS"
+          echo "Total tests: $TOTAL_TESTS"
+
+          echo "unit_tests=$UNIT_TESTS" >> $GITHUB_OUTPUT
+          echo "e2e_tests=$E2E_TESTS" >> $GITHUB_OUTPUT
+          echo "total_tests=$TOTAL_TESTS" >> $GITHUB_OUTPUT
+
+      - name: Update test count gist
+        uses: schneegans/dynamic-badges-action@v1.7.0
+        with:
+          auth: ${{ secrets.GIST_TOKEN }}
+          gistID: ${{ vars.TEST_BADGE_GIST_ID }}
+          filename: test-count.json
+          label: tests
+          message: ${{ steps.count-tests.outputs.total_tests }}
+          color: brightgreen
+          namedLogo: vitest
+          logoColor: white

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # SonicJS
 
 [![PR Tests](https://github.com/lane711/sonicjs/actions/workflows/pr-tests.yml/badge.svg)](https://github.com/lane711/sonicjs/actions/workflows/pr-tests.yml)
+[![codecov](https://codecov.io/gh/lane711/sonicjs/branch/main/graph/badge.svg)](https://codecov.io/gh/lane711/sonicjs)
+[![Tests](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/lane711/TEST_BADGE_GIST_ID/raw/test-count.json)](https://github.com/lane711/sonicjs)
 [![npm version](https://img.shields.io/npm/v/@sonicjs-cms/core.svg)](https://www.npmjs.com/package/@sonicjs-cms/core)
 [![npm downloads](https://img.shields.io/npm/dm/@sonicjs-cms/core.svg)](https://www.npmjs.com/package/@sonicjs-cms/core)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,6 +68,7 @@
     "lint": "eslint src/",
     "lint:fix": "eslint src/ --fix",
     "test": "vitest --run",
+    "test:cov": "vitest --run --coverage",
     "test:watch": "vitest",
     "prepublishOnly": "npm run build"
   },
@@ -107,6 +108,7 @@
     "semver": "^7.7.3"
   },
   "devDependencies": {
+    "@vitest/coverage-v8": "^4.0.5",
     "@cloudflare/workers-types": "^4.20251014.0",
     "@types/node": "^24.9.2",
     "@typescript-eslint/eslint-plugin": "^8.50.0",


### PR DESCRIPTION
## Summary
- Add code coverage reporting via Codecov
- Add dynamic test count badge that updates automatically on push to main
- Update README with new badges

## Changes
- Modified `.github/workflows/pr-tests.yml` to run tests with coverage and upload to Codecov
- Created `.github/workflows/update-badges.yml` to count tests and update a gist-based badge
- Added `test:cov` script to `packages/core/package.json`
- Updated `README.md` with Codecov and test count badges

## Setup Required

### 1. Codecov Setup
1. Go to [codecov.io](https://codecov.io) and sign in with GitHub
2. Add the `lane711/sonicjs` repository
3. Copy the upload token
4. Add it as a repository secret: `CODECOV_TOKEN`

### 2. Dynamic Test Count Badge Setup
1. Create a new **public** gist at https://gist.github.com with any initial content (e.g., `{}`)
2. Copy the gist ID from the URL (the long alphanumeric string)
3. Add repository variable: `TEST_BADGE_GIST_ID` = your gist ID
4. Create a Personal Access Token (classic) with `gist` scope
5. Add repository secret: `GIST_TOKEN` = your PAT
6. Update the README badge URL: replace `TEST_BADGE_GIST_ID` with your actual gist ID

### New Badges
Once configured, the README will show:
- **Codecov** - Code coverage percentage
- **Tests** - Dynamic count of all unit + e2e tests (currently 1200+)

## Test plan
- [x] Verify pr-tests.yml syntax is valid
- [x] Verify update-badges.yml syntax is valid
- [ ] After merge: verify Codecov upload works
- [ ] After merge: verify test count badge updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)