### PR TITLE
fix: URL-encode test count badge endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PR Tests](https://github.com/lane711/sonicjs/actions/workflows/pr-tests.yml/badge.svg)](https://github.com/lane711/sonicjs/actions/workflows/pr-tests.yml)
 [![codecov](https://codecov.io/gh/lane711/sonicjs/branch/main/graph/badge.svg)](https://codecov.io/gh/lane711/sonicjs)
-[![Tests](https://img.shields.io/endpoint?url=https://gist.githubusercontent.com/lane711/4fc1969ff683812bc49788d43fb4d7e2/raw/test-count.json)](https://github.com/lane711/sonicjs)
+[![Tests](https://img.shields.io/endpoint?url=https%3A%2F%2Fgist.githubusercontent.com%2Flane711%2F4fc1969ff683812bc49788d43fb4d7e2%2Fraw%2Ftest-count.json)](https://github.com/lane711/sonicjs)
 [![npm version](https://img.shields.io/npm/v/@sonicjs-cms/core.svg)](https://www.npmjs.com/package/@sonicjs-cms/core)
 [![npm downloads](https://img.shields.io/npm/dm/@sonicjs-cms/core.svg)](https://www.npmjs.com/package/@sonicjs-cms/core)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)


### PR DESCRIPTION
## Summary
URL-encode the gist endpoint URL for better compatibility with shields.io and to bust GitHub's image cache.

🤖 Generated with [Claude Code](https://claude.com/claude-code)