### PR TITLE
docs: add commit activity badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![npm downloads](https://img.shields.io/npm/dm/@sonicjs-cms/core.svg)](https://www.npmjs.com/package/@sonicjs-cms/core)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue.svg)](https://www.typescriptlang.org/)
+[![GitHub commit activity](https://img.shields.io/github/commit-activity/m/lane711/sonicjs)](https://github.com/lane711/sonicjs/commits/main)
 
 A modern, TypeScript-first headless CMS built for Cloudflare's edge platform with Hono.js.
 


### PR DESCRIPTION
## Summary
- Add GitHub commit activity badge showing monthly commit frequency to the README badges section
- Badge demonstrates active project maintenance to potential users/contributors

## Test plan
- [x] Verify badge renders correctly on GitHub README
- [x] Confirm badge links to commits page

🤖 Generated with [Claude Code](https://claude.com/claude-code)