### PR TITLE
docs: add Claude Code agents info to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ npx create-sonicjs@latest my-app
 - TypeScript types for autocomplete
 - Clear conventions and patterns
 - Built for AI-assisted development
+- **12 specialized Claude Code agents** for development ([View all agents](https://sonicjs.com/ai-agents))
 
 ## 🛠 Technology Stack
 


### PR DESCRIPTION
## Summary

Add mention of 12 specialized Claude Code agents under the AI-Friendly Architecture section with a link to the documentation page.

## Changes

Added to README under "AI-Friendly Architecture":
```
- **12 specialized Claude Code agents** for development ([View all agents](https://sonicjs.com/ai-agents))
```

## Test plan

- [x] Link is valid
- [x] README renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)