### PR TITLE
feat: add Open Collective sponsorship option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ npx create-sonicjs@latest my-app
 ```
 
 [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-pink?style=for-the-badge&logo=github-sponsors)](https://github.com/sponsors/lane711)
+[![Open Collective](https://img.shields.io/badge/Open_Collective-Support-7FADF2?style=for-the-badge&logo=opencollective)](https://opencollective.com/sonicjs)
 
 [![Deploy to Cloudflare](https://deploy.workers.cloudflare.com/button)](https://deploy.workers.cloudflare.com/?url=https://github.com/lane711/sonicjs-deploy-now)
 
@@ -398,8 +399,11 @@ We welcome contributions! Please see our [contributing guidelines](https://sonic
 SonicJS is 100% open source and free forever. If you find it useful, please consider sponsoring:
 
 [![Sponsor on GitHub](https://img.shields.io/badge/Sponsor_on_GitHub-%E2%9D%A4-pink?style=for-the-badge&logo=github-sponsors)](https://github.com/sponsors/lane711)
+[![Support on Open Collective](https://img.shields.io/badge/Open_Collective-Support-7FADF2?style=for-the-badge&logo=opencollective)](https://opencollective.com/sonicjs)
 
 **100% of sponsorship funds go to marketing** - spreading the word about SonicJS to help grow our community. The more developers who know about us, the stronger we become!
+
+> SonicJS is a member of [Open Source Collective](https://opencollective.com/sonicjs), a 501(c)(3) nonprofit. Donations are tax-deductible for US contributors.
 
 ### Thank You to Our Sponsors
 

--- a/www/src/app/sponsor/page.mdx
+++ b/www/src/app/sponsor/page.mdx
@@ -1,7 +1,7 @@
 export const metadata = {
   title: 'Sponsor SonicJS - Support the World\'s Fastest Headless CMS',
   description:
-    'Support SonicJS development through GitHub Sponsors. Help keep the world\'s fastest headless CMS free and actively maintained.',
+    'Support SonicJS development through GitHub Sponsors or Open Collective. Tax-deductible donations available via 501(c)(3). Help keep the world\'s fastest headless CMS free and actively maintained.',
 }
 
 export const sections = [
@@ -280,7 +280,28 @@ Ready to support SonicJS? Choose your preferred platform:
         <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
       </svg>
     </a>
+    <a
+      href="https://opencollective.com/sonicjs"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="flex items-center gap-4 rounded-xl border-2 border-zinc-200 dark:border-zinc-700 p-6 hover:border-blue-500 dark:hover:border-blue-500 transition group"
+    >
+      <div className="text-4xl">🌐</div>
+      <div>
+        <h3 className="text-lg font-bold m-0 group-hover:text-blue-600 dark:group-hover:text-blue-400 transition">Open Collective</h3>
+        <p className="text-sm text-zinc-600 dark:text-zinc-400 m-0">Tax-deductible via 501(c)(3)</p>
+      </div>
+      <svg className="w-5 h-5 ml-auto text-zinc-400 group-hover:text-blue-500 transition" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
+      </svg>
+    </a>
   </div>
+</div>
+
+<div className="not-prose my-6 p-4 rounded-lg bg-blue-50 dark:bg-blue-950/30 border border-blue-200 dark:border-blue-800">
+  <p className="text-sm text-blue-800 dark:text-blue-200 m-0">
+    <strong>Tax-deductible donations:</strong> SonicJS is a member of <a href="https://opencollective.com/sonicjs" className="underline">Open Source Collective</a>, a 501(c)(3) nonprofit. Donations through Open Collective are tax-deductible for US contributors.
+  </p>
 </div>
 
 ### For Businesses
@@ -335,9 +356,12 @@ A huge thank you to all our sponsors who make SonicJS possible!
 Whether you sponsor, contribute code, write documentation, or just use SonicJS - thank you for being part of this community. Every contribution matters.
 
 <div className="not-prose mt-8">
-  <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+  <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
     <Button href="https://github.com/sponsors/lane711" variant="primary">
       <>❤️ Sponsor on GitHub</>
+    </Button>
+    <Button href="https://opencollective.com/sonicjs" variant="primary">
+      <>🌐 Open Collective</>
     </Button>
     <Button href="/community" variant="secondary">
       <>Join the Community</>


### PR DESCRIPTION
## Summary
- Add Open Collective as a sponsorship platform alongside GitHub Sponsors
- Highlight tax-deductible benefits through Open Source Collective (501(c)(3))
- Update both README and website sponsor page

## Changes
- **README.md**: Added Open Collective badges in Get Started and Sponsor sections, plus 501(c)(3) info
- **www/src/app/sponsor/page.mdx**: Added Open Collective card, info box about tax benefits, updated metadata

## Testing
- [x] Visual review of badge rendering
- [x] Links verified to https://opencollective.com/sonicjs

## Checklist
- [x] Code follows project conventions
- [x] No new TypeScript errors introduced
- [x] Documentation/marketing content only (no code changes requiring tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)