### PR TITLE
docs: add HS256 algorithm to JWT sign/verify examples

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -163,7 +163,7 @@ export class AuthManager {
       iat: Math.floor(Date.now() / 1000)
     }
 
-    return await sign(payload, JWT_SECRET)
+    return await sign(payload, JWT_SECRET, 'HS256')
   }
 }
 ```
@@ -188,7 +188,7 @@ console.log(payload.userId, payload.email, payload.role)
 ```typescript
 static async verifyToken(token: string): Promise<JWTPayload | null> {
   try {
-    const payload = await verify(token, JWT_SECRET) as JWTPayload
+    const payload = await verify(token, JWT_SECRET, 'HS256') as JWTPayload
 
     // Check if token is expired
     if (payload.exp < Math.floor(Date.now() / 1000)) {


### PR DESCRIPTION
## Summary
- Updates authentication documentation to include the `'HS256'` algorithm parameter in JWT `sign()` and `verify()` examples
- Aligns docs with the fix from PR #505

## Context
PR #505 fixed issue #500 (session expiration bug) by adding the explicit `'HS256'` algorithm parameter. The documentation examples were not updated to reflect this change.

## Test plan
- [ ] Verify documentation renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)