### PR TITLE
docs: add Analytics plugin and Field Types Reference

### DIFF
--- a/www/src/app/field-types/page.mdx
+++ b/www/src/app/field-types/page.mdx
@@ -1,0 +1,924 @@
+export const metadata = {
+  title: 'Field Types Reference - SonicJS',
+  description:
+    'Complete reference for all SonicJS collection field types including text, number, boolean, date, select, media, richtext, and structured types.',
+}
+
+export const sections = [
+  { title: 'Overview', id: 'overview' },
+  { title: 'Text Fields', id: 'text-fields' },
+  { title: 'Number Fields', id: 'number-fields' },
+  { title: 'Boolean Fields', id: 'boolean-fields' },
+  { title: 'Date Fields', id: 'date-fields' },
+  { title: 'Selection Fields', id: 'selection-fields' },
+  { title: 'Media Fields', id: 'media-fields' },
+  { title: 'Rich Text Fields', id: 'rich-text-fields' },
+  { title: 'Structured Fields', id: 'structured-fields' },
+  { title: 'Reference Fields', id: 'reference-fields' },
+  { title: 'Field Configuration', id: 'field-configuration' },
+]
+
+# Field Types Reference
+
+Complete reference for all available field types in SonicJS collection schemas. {{ className: 'lead' }}
+
+---
+
+## Overview
+
+Field types define the structure and validation of content in your collections. Each field type has specific rendering, storage, and validation behavior.
+
+### Common Properties
+
+All field types support these common properties:
+
+<CodeGroup title="Common Field Properties">
+
+```typescript
+interface FieldConfig {
+  type: FieldType           // Required: The field type
+  title?: string            // Display label
+  description?: string      // Help text shown below field
+  required?: boolean        // Is the field required (default: false)
+  default?: any            // Default value
+  placeholder?: string      // Placeholder text
+}
+```
+
+</CodeGroup>
+
+---
+
+## Text Fields
+
+### string
+
+Basic text input for short content.
+
+<CodeGroup title="String Field">
+
+```typescript
+{
+  type: 'string',
+  title: 'Title',
+  required: true,
+  maxLength: 200,
+  placeholder: 'Enter a title',
+  pattern: '^[a-zA-Z0-9 ]+$'  // Optional regex validation
+}
+```
+
+</CodeGroup>
+
+**Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `maxLength` | number | Maximum characters allowed |
+| `minLength` | number | Minimum characters required |
+| `pattern` | string | Regex pattern for validation |
+| `placeholder` | string | Placeholder text |
+
+**Storage:** `VARCHAR(255)`
+
+---
+
+### textarea
+
+Multi-line text input for longer content.
+
+<CodeGroup title="Textarea Field">
+
+```typescript
+{
+  type: 'textarea',
+  title: 'Description',
+  required: true,
+  rows: 5,
+  maxLength: 1000,
+  placeholder: 'Enter a description'
+}
+```
+
+</CodeGroup>
+
+**Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `rows` | number | Height in rows (default: 3) |
+| `maxLength` | number | Maximum characters |
+| `placeholder` | string | Placeholder text |
+
+**Storage:** `TEXT`
+
+---
+
+### slug
+
+URL-friendly identifier with auto-generation and uniqueness checking.
+
+<CodeGroup title="Slug Field">
+
+```typescript
+{
+  type: 'slug',
+  title: 'URL Slug',
+  required: true,
+  maxLength: 100
+}
+```
+
+</CodeGroup>
+
+**Features:**
+- Auto-generates from title field
+- Validates format (lowercase, numbers, hyphens only)
+- Checks for duplicates in collection
+- Regenerate button in admin UI
+
+**Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `maxLength` | number | Maximum length (default: 100) |
+| `pattern` | string | Validation pattern (default: `^[a-z0-9-]+$`) |
+
+**Storage:** `VARCHAR(100)`
+
+---
+
+### email
+
+Email address field with validation.
+
+<CodeGroup title="Email Field">
+
+```typescript
+{
+  type: 'email',
+  title: 'Email Address',
+  required: true,
+  placeholder: 'user@example.com'
+}
+```
+
+</CodeGroup>
+
+**Storage:** `VARCHAR(255)`
+
+---
+
+### url
+
+URL field for links.
+
+<CodeGroup title="URL Field">
+
+```typescript
+{
+  type: 'url',
+  title: 'Website',
+  placeholder: 'https://example.com'
+}
+```
+
+</CodeGroup>
+
+**Storage:** `VARCHAR(500)`
+
+---
+
+## Number Fields
+
+### number
+
+Numeric input with optional min/max/step validation.
+
+<CodeGroup title="Number Field">
+
+```typescript
+{
+  type: 'number',
+  title: 'Price',
+  required: true,
+  min: 0,
+  max: 10000,
+  step: 0.01,
+  placeholder: '0.00'
+}
+```
+
+</CodeGroup>
+
+**Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `min` | number | Minimum value |
+| `max` | number | Maximum value |
+| `step` | number | Increment step (default: 1) |
+
+**Storage:** `DECIMAL(10,2)`
+
+---
+
+## Boolean Fields
+
+### boolean / checkbox
+
+Toggle or checkbox for true/false values.
+
+<CodeGroup title="Boolean Field">
+
+```typescript
+{
+  type: 'boolean',
+  title: 'Published',
+  default: false,
+  checkboxLabel: 'Make this content public'
+}
+```
+
+</CodeGroup>
+
+**Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `checkboxLabel` | string | Label next to checkbox |
+| `default` | boolean | Default value (default: false) |
+
+**Storage:** `BOOLEAN`
+
+---
+
+## Date Fields
+
+### date
+
+Date picker without time.
+
+<CodeGroup title="Date Field">
+
+```typescript
+{
+  type: 'date',
+  title: 'Publication Date',
+  min: '2024-01-01',
+  max: '2030-12-31'
+}
+```
+
+</CodeGroup>
+
+**Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `min` | string | Minimum date (YYYY-MM-DD) |
+| `max` | string | Maximum date (YYYY-MM-DD) |
+| `defaultToday` | boolean | Default to current date |
+
+**Storage:** `DATE`
+
+---
+
+### datetime
+
+Date and time picker.
+
+<CodeGroup title="DateTime Field">
+
+```typescript
+{
+  type: 'datetime',
+  title: 'Event Start',
+  required: true
+}
+```
+
+</CodeGroup>
+
+**Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `min` | string | Minimum datetime |
+| `max` | string | Maximum datetime |
+
+**Storage:** `DATETIME`
+
+---
+
+## Selection Fields
+
+### select
+
+Dropdown selection from predefined options.
+
+<CodeGroup title="Select Field">
+
+```typescript
+{
+  type: 'select',
+  title: 'Status',
+  required: true,
+  enum: ['draft', 'published', 'archived'],
+  enumLabels: ['Draft', 'Published', 'Archived'],
+  default: 'draft'
+}
+```
+
+</CodeGroup>
+
+**Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `enum` | string[] | Option values |
+| `enumLabels` | string[] | Display labels for options |
+| `multiple` | boolean | Allow multiple selections |
+| `searchable` | boolean | Enable search/filter |
+| `allowCustom` | boolean | Allow user-entered values |
+
+**Storage:** `VARCHAR(255)` (single) or `JSON` (multiple)
+
+---
+
+### Multiselect
+
+Use select with `multiple: true` for multiple selection.
+
+<CodeGroup title="Multiselect Field">
+
+```typescript
+{
+  type: 'select',
+  title: 'Tags',
+  multiple: true,
+  enum: ['javascript', 'typescript', 'react', 'vue', 'angular'],
+  enumLabels: ['JavaScript', 'TypeScript', 'React', 'Vue', 'Angular']
+}
+```
+
+</CodeGroup>
+
+**Storage:** `JSON` (array of values)
+
+---
+
+### radio
+
+Radio button group for single selection.
+
+<CodeGroup title="Radio Field">
+
+```typescript
+{
+  type: 'radio',
+  title: 'Priority',
+  enum: ['low', 'medium', 'high'],
+  enumLabels: ['Low', 'Medium', 'High'],
+  default: 'medium'
+}
+```
+
+</CodeGroup>
+
+**Storage:** `VARCHAR(255)`
+
+---
+
+## Media Fields
+
+### media
+
+File upload with preview for images, videos, and documents.
+
+<CodeGroup title="Media Field">
+
+```typescript
+{
+  type: 'media',
+  title: 'Featured Image',
+  required: true,
+  allowedTypes: ['image/jpeg', 'image/png', 'image/webp'],
+  maxFileSize: 5242880  // 5MB
+}
+```
+
+</CodeGroup>
+
+**Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `allowedTypes` | string[] | Allowed MIME types (default: `['image/*']`) |
+| `maxFileSize` | number | Max file size in bytes (default: 10MB) |
+| `multiple` | boolean | Allow multiple files |
+| `autoUpload` | boolean | Upload immediately on selection |
+
+**Common MIME Types:**
+- Images: `image/jpeg`, `image/png`, `image/gif`, `image/webp`, `image/svg+xml`
+- Videos: `video/mp4`, `video/webm`
+- Documents: `application/pdf`, `application/msword`
+
+**Storage:** `VARCHAR(500)` (URL) or `JSON` (multiple)
+
+---
+
+### color
+
+Color picker with hex value.
+
+<CodeGroup title="Color Field">
+
+```typescript
+{
+  type: 'color',
+  title: 'Brand Color',
+  default: '#3B82F6'
+}
+```
+
+</CodeGroup>
+
+**Storage:** `VARCHAR(7)` (hex code)
+
+---
+
+## Rich Text Fields
+
+### richtext
+
+WYSIWYG editor for formatted content.
+
+<CodeGroup title="RichText Field">
+
+```typescript
+{
+  type: 'richtext',
+  title: 'Content',
+  required: true,
+  height: 400,
+  toolbar: 'full',
+  allowImages: true
+}
+```
+
+</CodeGroup>
+
+**Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `height` | number | Editor height in pixels (default: 300) |
+| `toolbar` | string | `'simple'` or `'full'` (default: 'full') |
+| `allowImages` | boolean | Allow image insertion |
+
+**Storage:** `TEXT` (HTML)
+
+<Note>
+Falls back to textarea if no rich text editor plugin is active.
+</Note>
+
+---
+
+### quill
+
+Quill editor (requires Quill Editor Plugin).
+
+<CodeGroup title="Quill Field">
+
+```typescript
+{
+  type: 'quill',
+  title: 'Article Body',
+  required: true,
+  theme: 'snow',
+  height: 400,
+  toolbar: 'full'
+}
+```
+
+</CodeGroup>
+
+**Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `theme` | string | `'snow'` or `'bubble'` (default: 'snow') |
+| `height` | number | Editor height |
+| `toolbar` | string | `'full'`, `'simple'`, or `'minimal'` |
+
+**Toolbar Presets:**
+- `full`: Headers, formatting, colors, lists, links, images
+- `simple`: Bold, italic, underline, lists, links
+- `minimal`: Bold, italic, links
+
+**Storage:** `TEXT` (HTML)
+
+---
+
+### mdxeditor / markdown
+
+Markdown editor (requires EasyMDE Plugin).
+
+<CodeGroup title="Markdown Field">
+
+```typescript
+{
+  type: 'mdxeditor',
+  title: 'Documentation',
+  height: 400
+}
+```
+
+</CodeGroup>
+
+**Storage:** `TEXT` (Markdown)
+
+---
+
+### tinymce
+
+TinyMCE editor (requires TinyMCE Plugin).
+
+<CodeGroup title="TinyMCE Field">
+
+```typescript
+{
+  type: 'tinymce',
+  title: 'Page Content',
+  required: true
+}
+```
+
+</CodeGroup>
+
+**Storage:** `TEXT` (HTML)
+
+---
+
+## Structured Fields
+
+### object
+
+Nested group of fields.
+
+<CodeGroup title="Object Field">
+
+```typescript
+{
+  type: 'object',
+  title: 'SEO Settings',
+  properties: {
+    metaTitle: {
+      type: 'string',
+      title: 'Meta Title',
+      maxLength: 60
+    },
+    metaDescription: {
+      type: 'textarea',
+      title: 'Meta Description',
+      maxLength: 160
+    },
+    keywords: {
+      type: 'string',
+      title: 'Keywords'
+    }
+  }
+}
+```
+
+</CodeGroup>
+
+**Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `properties` | object | Nested field definitions |
+
+**Storage:** `JSON`
+
+---
+
+### array
+
+Repeatable list of items.
+
+<CodeGroup title="Array Field - Simple">
+
+```typescript
+{
+  type: 'array',
+  title: 'Tags',
+  items: {
+    type: 'string'
+  }
+}
+```
+
+</CodeGroup>
+
+<CodeGroup title="Array Field - Objects">
+
+```typescript
+{
+  type: 'array',
+  title: 'Team Members',
+  items: {
+    type: 'object',
+    properties: {
+      name: { type: 'string', title: 'Name', required: true },
+      role: { type: 'string', title: 'Role' },
+      photo: { type: 'media', title: 'Photo' }
+    }
+  }
+}
+```
+
+</CodeGroup>
+
+**Features:**
+- Add/remove items
+- Drag-to-reorder
+- Move up/down buttons
+
+**Storage:** `JSON`
+
+---
+
+### blocks
+
+Discriminated union for flexible content blocks (page builders).
+
+<CodeGroup title="Blocks Field">
+
+```typescript
+{
+  type: 'array',
+  title: 'Page Content',
+  items: {
+    type: 'object',
+    discriminator: 'blockType',
+    blocks: {
+      text: {
+        label: 'Text Block',
+        description: 'A heading with body text',
+        properties: {
+          heading: { type: 'string', title: 'Heading' },
+          body: { type: 'richtext', title: 'Body' }
+        }
+      },
+      image: {
+        label: 'Image Block',
+        description: 'Full-width image with caption',
+        properties: {
+          image: { type: 'media', title: 'Image', required: true },
+          caption: { type: 'string', title: 'Caption' },
+          alt: { type: 'string', title: 'Alt Text' }
+        }
+      },
+      cta: {
+        label: 'Call to Action',
+        description: 'Button with text',
+        properties: {
+          title: { type: 'string', title: 'Title' },
+          description: { type: 'textarea', title: 'Description' },
+          buttonText: { type: 'string', title: 'Button Text' },
+          buttonUrl: { type: 'url', title: 'Button URL' }
+        }
+      }
+    }
+  }
+}
+```
+
+</CodeGroup>
+
+**Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `discriminator` | string | Field name for block type (default: 'blockType') |
+| `blocks` | object | Block type definitions |
+
+**Block Definition:**
+| Property | Type | Description |
+|----------|------|-------------|
+| `label` | string | Display name in selector |
+| `description` | string | Help text |
+| `properties` | object | Field definitions for this block |
+
+**Features:**
+- Block type selector dropdown
+- Add any block type
+- Reorder blocks
+- Type-specific fields
+
+**Storage:** `JSON`
+
+---
+
+## Reference Fields
+
+### reference
+
+Link to content from another collection.
+
+<CodeGroup title="Reference Field - Single Collection">
+
+```typescript
+{
+  type: 'reference',
+  title: 'Author',
+  collection: 'users',
+  required: true
+}
+```
+
+</CodeGroup>
+
+<CodeGroup title="Reference Field - Multiple Collections">
+
+```typescript
+{
+  type: 'reference',
+  title: 'Related Content',
+  collection: ['blog_posts', 'pages', 'products']
+}
+```
+
+</CodeGroup>
+
+**Options:**
+| Option | Type | Description |
+|--------|------|-------------|
+| `collection` | string or string[] | Collection(s) to reference |
+
+**Storage:** `VARCHAR(255)` (content ID)
+
+---
+
+### json
+
+Raw JSON data field.
+
+<CodeGroup title="JSON Field">
+
+```typescript
+{
+  type: 'json',
+  title: 'Custom Data',
+  default: {}
+}
+```
+
+</CodeGroup>
+
+**Storage:** `JSON`
+
+---
+
+## Field Configuration
+
+### Complete Example
+
+<CodeGroup title="Full Collection Example">
+
+```typescript
+import { defineCollection } from '@sonicjs-cms/core'
+
+export default defineCollection({
+  name: 'blog_posts',
+  displayName: 'Blog Posts',
+  description: 'Blog articles and news',
+  schema: {
+    // Text fields
+    title: {
+      type: 'string',
+      title: 'Title',
+      required: true,
+      maxLength: 200
+    },
+    slug: {
+      type: 'slug',
+      title: 'URL Slug',
+      required: true
+    },
+    excerpt: {
+      type: 'textarea',
+      title: 'Excerpt',
+      maxLength: 300,
+      description: 'Short summary for listings'
+    },
+
+    // Rich content
+    content: {
+      type: 'richtext',
+      title: 'Content',
+      required: true
+    },
+
+    // Media
+    featuredImage: {
+      type: 'media',
+      title: 'Featured Image',
+      allowedTypes: ['image/*']
+    },
+
+    // Selection
+    status: {
+      type: 'select',
+      title: 'Status',
+      enum: ['draft', 'published', 'archived'],
+      enumLabels: ['Draft', 'Published', 'Archived'],
+      default: 'draft'
+    },
+    category: {
+      type: 'select',
+      title: 'Category',
+      enum: ['news', 'tutorial', 'announcement'],
+      enumLabels: ['News', 'Tutorial', 'Announcement']
+    },
+    tags: {
+      type: 'select',
+      title: 'Tags',
+      multiple: true,
+      enum: ['javascript', 'react', 'nodejs', 'cloudflare']
+    },
+
+    // Date
+    publishedAt: {
+      type: 'datetime',
+      title: 'Publish Date'
+    },
+
+    // Boolean
+    featured: {
+      type: 'boolean',
+      title: 'Featured',
+      checkboxLabel: 'Show on homepage',
+      default: false
+    },
+
+    // Reference
+    author: {
+      type: 'reference',
+      title: 'Author',
+      collection: 'users',
+      required: true
+    },
+
+    // Structured
+    seo: {
+      type: 'object',
+      title: 'SEO',
+      properties: {
+        metaTitle: { type: 'string', title: 'Meta Title' },
+        metaDescription: { type: 'textarea', title: 'Meta Description' }
+      }
+    },
+
+    // Array
+    relatedPosts: {
+      type: 'array',
+      title: 'Related Posts',
+      items: {
+        type: 'reference',
+        collection: 'blog_posts'
+      }
+    }
+  }
+})
+```
+
+</CodeGroup>
+
+### Validation Summary
+
+| Field Type | Client Validation | Server Validation |
+|------------|-------------------|-------------------|
+| string | HTML5 + pattern | Zod schema |
+| textarea | HTML5 + maxLength | Zod schema |
+| slug | Format + uniqueness API | Uniqueness check |
+| number | HTML5 min/max/step | Zod schema |
+| boolean | - | Zod schema |
+| date/datetime | HTML5 min/max | Zod schema |
+| select | Valid option check | Enum validation |
+| media | File type/size | MIME validation |
+| richtext | - | HTML sanitization |
+| object | Nested validation | Zod schema |
+| array | Item validation | Zod schema |
+| reference | - | Exists check |
+
+---
+
+## Next Steps
+
+<div className="not-prose">
+  <Button href="/collections" variant="text" arrow="right">
+    <>Learn about collections</>
+  </Button>
+</div>
+
+<div className="not-prose mt-4">
+  <Button href="/api" variant="text" arrow="right">
+    <>Content API reference</>
+  </Button>
+</div>
+
+<div className="not-prose mt-4">
+  <Button href="/plugins/core" variant="text" arrow="right">
+    <>Rich text editor plugins</>
+  </Button>
+</div>

--- a/www/src/app/plugins/analytics/page.mdx
+++ b/www/src/app/plugins/analytics/page.mdx
@@ -1,0 +1,604 @@
+export const metadata = {
+  title: 'Analytics Plugin - SonicJS',
+  description:
+    'Built-in analytics and insights for SonicJS with page view tracking, user sessions, custom events, real-time monitoring, and detailed reports.',
+}
+
+export const sections = [
+  { title: 'Overview', id: 'overview' },
+  { title: 'Features', id: 'features' },
+  { title: 'Setup', id: 'setup' },
+  { title: 'Tracking Page Views', id: 'tracking-page-views' },
+  { title: 'Custom Events', id: 'custom-events' },
+  { title: 'API Reference', id: 'api-reference' },
+  { title: 'Analytics Service', id: 'analytics-service' },
+  { title: 'Admin Dashboard', id: 'admin-dashboard' },
+  { title: 'Configuration', id: 'configuration' },
+]
+
+# Analytics Plugin
+
+Built-in analytics and insights for SonicJS with page view tracking, user sessions, custom events, real-time monitoring, and detailed reporting. {{ className: 'lead' }}
+
+---
+
+## Overview
+
+The Analytics plugin provides comprehensive visitor and content analytics without requiring external services. Track page views, user behavior, and custom events directly within your SonicJS application.
+
+<FeatureGrid
+  features={[
+    {
+      icon: '📊',
+      title: 'Page View Tracking',
+      description: 'Automatic tracking of all page visits with referrer and user agent data',
+    },
+    {
+      icon: '👥',
+      title: 'Session Management',
+      description: 'Track user sessions with duration and behavior patterns',
+    },
+    {
+      icon: '⚡',
+      title: 'Real-time Analytics',
+      description: 'Monitor active users and live page activity',
+    },
+    {
+      icon: '📈',
+      title: 'Custom Reports',
+      description: 'Generate detailed reports with custom date ranges',
+    },
+  ]}
+  columns={2}
+/>
+
+---
+
+## Features
+
+### Automatic Tracking
+
+- Page views tracked automatically via middleware
+- Request method, status, and duration captured
+- User agent and referrer recorded
+- IP address tracking (from Cloudflare headers)
+
+### Session Analytics
+
+- Unique session IDs per visitor
+- Session duration tracking
+- User behavior patterns
+- Bounce rate calculation
+
+### Custom Events
+
+- Track any custom event type
+- Associate events with users and sessions
+- Store event metadata as JSON
+- Query events by type or time range
+
+### Reporting
+
+- Traffic reports by date range
+- Top pages by views
+- User engagement metrics
+- Export capabilities
+
+---
+
+## Setup
+
+The Analytics plugin is included with SonicJS core and enabled by default.
+
+### Verify Plugin Status
+
+Navigate to **Admin > Plugins** to confirm the Analytics plugin is active.
+
+### Database Tables
+
+The plugin automatically creates these tables:
+
+| Table | Purpose |
+|-------|---------|
+| `analytics_pageviews` | Stores page view records |
+| `analytics_events` | Stores custom event data |
+
+---
+
+## Tracking Page Views
+
+Page views are tracked automatically by the analytics middleware. Each request captures:
+
+<CodeGroup title="Page View Data">
+
+```typescript
+interface PageView {
+  path: string           // URL path visited
+  title?: string         // Page title
+  referrer?: string      // HTTP referrer
+  userAgent?: string     // Browser user agent
+  ipAddress?: string     // Visitor IP address
+  sessionId?: string     // Unique session ID
+  userId?: number        // User ID (if authenticated)
+  duration?: number      // Time on page (milliseconds)
+}
+```
+
+</CodeGroup>
+
+### Manual Page View Tracking
+
+Track page views programmatically:
+
+<CodeGroup title="Track Page View">
+
+```typescript
+import { analyticsService } from '@sonicjs-cms/core/plugins'
+
+// Track a page view
+const result = await analyticsService.trackPageView({
+  path: '/products/item-123',
+  title: 'Product Detail - Widget Pro',
+  sessionId: 'session-xyz',
+  userId: 456
+})
+
+console.log('View tracked:', result.viewId)
+```
+
+</CodeGroup>
+
+---
+
+## Custom Events
+
+Track custom events to measure user interactions and conversions.
+
+### Event Structure
+
+<CodeGroup title="Event Data">
+
+```typescript
+interface AnalyticsEvent {
+  eventType: string      // Category: 'auth', 'content', 'conversion', etc.
+  eventName: string      // Specific event: 'user_login', 'purchase', etc.
+  eventData?: object     // Additional metadata
+  path?: string          // Page where event occurred
+  sessionId?: string     // Associated session
+  userId?: number        // Associated user
+}
+```
+
+</CodeGroup>
+
+### Track Custom Events
+
+<CodeGroup title="Track Events">
+
+```typescript
+import { analyticsService } from '@sonicjs-cms/core/plugins'
+
+// Track a conversion event
+await analyticsService.trackEvent({
+  eventType: 'conversion',
+  eventName: 'purchase_completed',
+  eventData: {
+    orderId: 'order-12345',
+    amount: 99.99,
+    currency: 'USD',
+    items: 3
+  },
+  sessionId: 'session-xyz',
+  userId: 456
+})
+
+// Track a feature usage event
+await analyticsService.trackEvent({
+  eventType: 'feature',
+  eventName: 'export_clicked',
+  eventData: {
+    format: 'csv',
+    recordCount: 150
+  }
+})
+
+// Track a content event
+await analyticsService.trackEvent({
+  eventType: 'content',
+  eventName: 'article_shared',
+  eventData: {
+    articleId: 'post-789',
+    platform: 'twitter'
+  },
+  path: '/blog/my-article'
+})
+```
+
+</CodeGroup>
+
+### Common Event Types
+
+| Event Type | Use Case |
+|------------|----------|
+| `auth` | Login, logout, registration |
+| `content` | Views, shares, downloads |
+| `conversion` | Purchases, sign-ups, goals |
+| `feature` | Feature usage, button clicks |
+| `error` | Client-side errors, failures |
+| `custom` | Any other events |
+
+---
+
+## API Reference
+
+All analytics endpoints require authentication with `admin` or `analytics:read` role.
+
+### Get Statistics
+
+<Row>
+  <Col>
+    Retrieve analytics overview statistics for a time range.
+
+    **Query Parameters:**
+    - `range` - Time range: `1d`, `7d`, `30d`, `90d` (default: `7d`)
+    - `metric` - Specific metric: `pageviews`, `sessions`, `users`, `all` (default: `all`)
+  </Col>
+  <Col>
+    <CodeGroup title="Request">
+
+    ```bash
+    curl -X GET 'https://your-app.workers.dev/api/analytics/stats?range=7d' \
+      -H 'Authorization: Bearer YOUR_TOKEN'
+    ```
+
+    </CodeGroup>
+
+    <CodeGroup title="Response">
+
+    ```json
+    {
+      "message": "Analytics stats",
+      "data": {
+        "pageviews": 12500,
+        "uniqueVisitors": 3200,
+        "sessions": 4800,
+        "avgSessionDuration": 245,
+        "bounceRate": 0.35,
+        "topPages": [
+          { "path": "/", "views": 3200 },
+          { "path": "/about", "views": 1800 },
+          { "path": "/contact", "views": 950 }
+        ],
+        "timeRange": "7d"
+      }
+    }
+    ```
+
+    </CodeGroup>
+  </Col>
+</Row>
+
+### Track Event
+
+<Row>
+  <Col>
+    Track a custom analytics event.
+
+    **Request Body:**
+    - `eventType` (required) - Event category
+    - `eventName` (required) - Specific event name
+    - `eventData` - Optional metadata object
+    - `path` - Page path
+    - `sessionId` - Session identifier
+    - `userId` - User ID
+  </Col>
+  <Col>
+    <CodeGroup title="Request">
+
+    ```bash
+    curl -X POST 'https://your-app.workers.dev/api/analytics/track' \
+      -H 'Authorization: Bearer YOUR_TOKEN' \
+      -H 'Content-Type: application/json' \
+      -d '{
+        "eventType": "conversion",
+        "eventName": "signup_completed",
+        "eventData": { "plan": "pro" }
+      }'
+    ```
+
+    </CodeGroup>
+
+    <CodeGroup title="Response">
+
+    ```json
+    {
+      "message": "Event tracked successfully",
+      "eventId": "event-1234567890"
+    }
+    ```
+
+    </CodeGroup>
+  </Col>
+</Row>
+
+### Generate Report
+
+<Row>
+  <Col>
+    Generate detailed analytics reports.
+
+    **Query Parameters:**
+    - `type` - Report type: `traffic`, `pages`, `users`, `behavior` (default: `traffic`)
+    - `start` - Start date (ISO format)
+    - `end` - End date (ISO format)
+  </Col>
+  <Col>
+    <CodeGroup title="Request">
+
+    ```bash
+    curl -X GET 'https://your-app.workers.dev/api/analytics/reports?type=traffic&start=2024-01-01&end=2024-01-31' \
+      -H 'Authorization: Bearer YOUR_TOKEN'
+    ```
+
+    </CodeGroup>
+
+    <CodeGroup title="Response">
+
+    ```json
+    {
+      "message": "Analytics report",
+      "data": {
+        "reportType": "traffic",
+        "dateRange": {
+          "start": "2024-01-01",
+          "end": "2024-01-31"
+        },
+        "data": []
+      }
+    }
+    ```
+
+    </CodeGroup>
+  </Col>
+</Row>
+
+### Real-time Data
+
+<Row>
+  <Col>
+    Get real-time analytics showing active users and pages.
+  </Col>
+  <Col>
+    <CodeGroup title="Request">
+
+    ```bash
+    curl -X GET 'https://your-app.workers.dev/api/analytics/realtime' \
+      -H 'Authorization: Bearer YOUR_TOKEN'
+    ```
+
+    </CodeGroup>
+
+    <CodeGroup title="Response">
+
+    ```json
+    {
+      "message": "Real-time analytics",
+      "data": {
+        "activeUsers": 23,
+        "activePages": [
+          { "path": "/", "users": 8 },
+          { "path": "/blog", "users": 5 },
+          { "path": "/products", "users": 4 }
+        ],
+        "recentEvents": []
+      }
+    }
+    ```
+
+    </CodeGroup>
+  </Col>
+</Row>
+
+---
+
+## Analytics Service
+
+Use the analytics service programmatically in your code.
+
+### Access the Service
+
+<CodeGroup title="Service Access">
+
+```typescript
+// In hooks or middleware with context
+const analyticsService = context.services?.analyticsService
+
+// Track page view
+const view = await analyticsService?.trackPageView({
+  path: '/my-page',
+  title: 'My Page'
+})
+
+// Track event
+const event = await analyticsService?.trackEvent({
+  eventType: 'custom',
+  eventName: 'button_clicked'
+})
+
+// Get statistics
+const stats = await analyticsService?.getStats('7d')
+console.log(`${stats.pageviews} views this week`)
+
+// Generate report
+const report = await analyticsService?.generateReport('traffic', {
+  start: '2024-01-01',
+  end: '2024-01-31'
+})
+```
+
+</CodeGroup>
+
+### Service Methods
+
+| Method | Parameters | Returns |
+|--------|------------|---------|
+| `trackPageView(data)` | PageView object | `{ viewId: string }` |
+| `trackEvent(event)` | AnalyticsEvent object | `{ eventId: string }` |
+| `getStats(range)` | `'1d'`, `'7d'`, `'30d'`, `'90d'` | Statistics object |
+| `generateReport(type, options)` | Report type and date range | `{ reportId: string }` |
+
+---
+
+## Admin Dashboard
+
+The plugin provides admin pages for viewing analytics.
+
+### Dashboard
+
+**Path:** `/admin/analytics`
+
+Overview of key metrics:
+- Total page views
+- Unique visitors
+- Session count
+- Top pages
+
+### Reports
+
+**Path:** `/admin/analytics/reports`
+
+Generate custom reports:
+- Select report type
+- Choose date range
+- Export data
+
+### Real-time
+
+**Path:** `/admin/analytics/realtime`
+
+Live monitoring:
+- Active user count
+- Active pages with visitor counts
+- Recent events feed
+
+### Settings
+
+**Path:** `/admin/analytics/settings`
+
+Configure the plugin:
+- Enable/disable tracking
+- Data retention settings
+- Feature toggles
+
+---
+
+## Configuration
+
+### Plugin Settings
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `trackPageViews` | boolean | `true` | Automatically track page views |
+| `trackUserSessions` | boolean | `true` | Track session duration and behavior |
+| `retentionDays` | number | `90` | Days to retain analytics data |
+
+### Permissions
+
+| Permission | Description |
+|------------|-------------|
+| `analytics:view` | View analytics data |
+| `analytics:read` | Read access to analytics API |
+| `analytics:export` | Export analytics reports |
+| `analytics:configure` | Change plugin settings |
+
+---
+
+## Hooks Integration
+
+The plugin integrates with these hooks:
+
+| Hook | Priority | Purpose |
+|------|----------|---------|
+| `REQUEST_START` | 1 | Initialize session tracking |
+| `REQUEST_END` | 1 | Finalize request metrics |
+| `USER_LOGIN` | 8 | Track login events |
+| `content:view` | 8 | Track content views |
+
+<CodeGroup title="Hook Example">
+
+```typescript
+// The plugin automatically tracks logins
+// You can also manually track with hooks
+
+hooks.register('content:view', async (data, context) => {
+  const analyticsService = context.services?.analyticsService
+
+  await analyticsService?.trackEvent({
+    eventType: 'content',
+    eventName: 'content_viewed',
+    eventData: {
+      contentId: data.id,
+      contentType: data.type,
+      title: data.title
+    }
+  })
+
+  return data
+})
+```
+
+</CodeGroup>
+
+---
+
+## Database Schema
+
+### analytics_pageviews
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | INTEGER | Primary key |
+| `path` | TEXT | Page path visited |
+| `title` | TEXT | Page title |
+| `referrer` | TEXT | HTTP referrer |
+| `user_agent` | TEXT | Browser user agent |
+| `ip_address` | TEXT | Visitor IP |
+| `session_id` | TEXT | Session identifier |
+| `user_id` | INTEGER | User ID if authenticated |
+| `duration` | INTEGER | Time on page (ms) |
+| `created_at` | INTEGER | Timestamp |
+
+### analytics_events
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `id` | INTEGER | Primary key |
+| `event_type` | TEXT | Event category |
+| `event_name` | TEXT | Event name |
+| `event_data` | TEXT | JSON metadata |
+| `path` | TEXT | Page path |
+| `session_id` | TEXT | Session identifier |
+| `user_id` | INTEGER | User ID |
+| `created_at` | INTEGER | Timestamp |
+
+---
+
+## Next Steps
+
+<div className="not-prose">
+  <Button href="/plugins" variant="text" arrow="right">
+    <>Explore other plugins</>
+  </Button>
+</div>
+
+<div className="not-prose mt-4">
+  <Button href="/hooks" variant="text" arrow="right">
+    <>Learn about hooks</>
+  </Button>
+</div>
+
+<div className="not-prose mt-4">
+  <Button href="/api" variant="text" arrow="right">
+    <>API reference</>
+  </Button>
+</div>

--- a/www/src/components/Navigation.tsx
+++ b/www/src/components/Navigation.tsx
@@ -265,6 +265,7 @@ export const navigation: Array<NavGroup> = [
       { title: 'Development Guide', href: '/plugins/development' },
       { title: 'Core Plugins', href: '/plugins/core' },
       { title: 'AI Search', href: '/plugins/ai-search' },
+      { title: 'Analytics', href: '/plugins/analytics' },
       { title: 'Workflow', href: '/plugins/workflow' },
       { title: 'Turnstile (Bot Protection)', href: '/plugins/turnstile' },
       { title: 'Email Templates', href: '/plugins/email-templates' },
@@ -275,6 +276,7 @@ export const navigation: Array<NavGroup> = [
     links: [
       { title: 'Configuration', href: '/configuration' },
       { title: 'Hook Reference', href: '/hooks' },
+      { title: 'Field Types', href: '/field-types' },
       { title: 'Security', href: '/security' },
       { title: 'Troubleshooting', href: '/troubleshooting' },
     ],


### PR DESCRIPTION
## Summary
- Add comprehensive Analytics plugin documentation covering page view tracking, custom events, API reference, and admin dashboard
- Add Field Types Reference with complete documentation of all collection field types (text, number, boolean, date, select, media, richtext, structured, reference)
- Update navigation with new pages under Plugin System and Reference sections

Part of Phase 3 of the documentation improvement initiative (see #572).

## Test plan
- [ ] Verify /plugins/analytics page renders correctly
- [ ] Verify /field-types page renders correctly
- [ ] Verify navigation shows new pages
- [ ] Check all code examples are properly formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)