### PR TITLE
fix: add URL Slug field type option to collection field dropdown

### DIFF
--- a/my-sonicjs-app/scripts/setup-worktree-db.sh
+++ b/my-sonicjs-app/scripts/setup-worktree-db.sh
@@ -90,12 +90,12 @@ echo "Local database cleared."
 # Run migrations on remote
 echo ""
 echo "Running migrations on remote database..."
-npx wrangler d1 migrations apply "$DB_NAME" --remote
+npx wrangler d1 migrations apply "$DB_NAME" --remote --yes
 
 # Run migrations on local
 echo ""
 echo "Running migrations on local database..."
-npx wrangler d1 migrations apply "$DB_NAME" --local
+npx wrangler d1 migrations apply "$DB_NAME" --local --yes
 
 # Seed admin user
 echo ""

--- a/packages/core/src/templates/pages/admin-collections-form.template.ts
+++ b/packages/core/src/templates/pages/admin-collections-form.template.ts
@@ -41,6 +41,7 @@ export interface CollectionFormData {
 function getFieldTypeBadge(fieldType: string): string {
   const typeLabels: Record<string, string> = {
     'text': 'Text',
+    'slug': 'URL Slug',
     'richtext': 'Rich Text (TinyMCE)',
     'quill': 'Rich Text (Quill)',
     'mdxeditor': 'EasyMDX',
@@ -53,6 +54,7 @@ function getFieldTypeBadge(fieldType: string): string {
   }
   const typeColors: Record<string, string> = {
     'text': 'bg-blue-500/10 dark:bg-blue-400/10 text-blue-700 dark:text-blue-300 ring-blue-500/20 dark:ring-blue-400/20',
+    'slug': 'bg-sky-500/10 dark:bg-sky-400/10 text-sky-700 dark:text-sky-300 ring-sky-500/20 dark:ring-sky-400/20',
     'richtext': 'bg-purple-500/10 dark:bg-purple-400/10 text-purple-700 dark:text-purple-300 ring-purple-500/20 dark:ring-purple-400/20',
     'quill': 'bg-purple-500/10 dark:bg-purple-400/10 text-purple-700 dark:text-purple-300 ring-purple-500/20 dark:ring-purple-400/20',
     'mdxeditor': 'bg-purple-500/10 dark:bg-purple-400/10 text-purple-700 dark:text-purple-300 ring-purple-500/20 dark:ring-purple-400/20',
@@ -546,6 +548,7 @@ export function renderCollectionFormPage(data: CollectionFormData): string {
               >
                 <option value="">Select field type...</option>
                 <option value="text">Text</option>
+                <option value="slug">URL Slug</option>
                 ${data.editorPlugins?.tinymce ? '<option value="richtext">Rich Text (TinyMCE)</option>' : ''}
                 ${data.editorPlugins?.quill ? '<option value="quill">Rich Text (Quill)</option>' : ''}
                 ${data.editorPlugins?.easyMdx ? '<option value="mdxeditor">EasyMDX</option>' : ''}
@@ -905,6 +908,9 @@ export function renderCollectionFormPage(data: CollectionFormData): string {
             case 'text':
               helpText.textContent = 'Single-line text input for short content';
               break;
+            case 'slug':
+              helpText.textContent = 'URL-friendly slug field, auto-generated from title';
+              break;
             case 'number':
               helpText.textContent = 'Numeric input field for integers or decimals';
               break;
@@ -1060,6 +1066,9 @@ export function renderCollectionFormPage(data: CollectionFormData): string {
           switch (this.value) {
             case 'text':
               helpText.textContent = 'Single-line text input for short content';
+              break;
+            case 'slug':
+              helpText.textContent = 'URL-friendly slug field, auto-generated from title';
               break;
             case 'number':
               helpText.textContent = 'Numeric input field for integers or decimals';


### PR DESCRIPTION
## Summary

- Adds "URL Slug" as a selectable field type option in the collection field dropdown
- Fixes the missing dropdown option from PR #530 (which was closed without being merged)

## Changes

- **`packages/core/src/templates/pages/admin-collections-form.template.ts`**:
  - Added `<option value="slug">URL Slug</option>` to field type dropdown
  - Added 'slug' to `typeLabels` and `typeColors` for proper badge display
  - Added help text for slug field type in both edit and add field handlers

- **`my-sonicjs-app/scripts/setup-worktree-db.sh`**:
  - Added `--yes` flag to wrangler migration commands to auto-confirm prompts

## Testing

- [x] Build succeeds (`npm run build`)
- [x] No TypeScript errors

## Checklist

- [x] Code follows project conventions
- [x] No new TypeScript errors introduced

Fixes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)