### PR TITLE
fix: use static Discord badge to prevent invalid server error

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![GitHub stars](https://img.shields.io/github/stars/lane711/sonicjs?style=social)](https://github.com/lane711/sonicjs)
 [![npm downloads](https://img.shields.io/npm/dm/@sonicjs-cms/core.svg)](https://www.npmjs.com/package/@sonicjs-cms/core)
 [![GitHub commit activity](https://img.shields.io/github/commit-activity/m/lane711/sonicjs)](https://github.com/lane711/sonicjs/commits)
-[![Discord](https://img.shields.io/discord/1149853789832142908?label=Discord&logo=discord)](https://discord.gg/8bMy6bv3sZ)
+[![Discord](https://img.shields.io/badge/Discord-Join%20Us-5865F2?logo=discord&logoColor=white)](https://discord.gg/8bMy6bv3sZ)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.x-blue.svg)](https://www.typescriptlang.org/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 


### PR DESCRIPTION
## Summary
- Fixed Discord badge in README showing "invalid server" error
- Changed from dynamic shields.io Discord badge to a static badge
- The static badge displays "Discord - Join Us" and links to the server

## Changes
- `README.md` - Updated Discord badge URL from dynamic server ID lookup to static badge format

## Testing
- [x] Verified new badge renders correctly via shields.io

## Notes
The dynamic Discord badge (`img.shields.io/discord/{server_id}`) requires the Discord server widget to be enabled. The static badge approach avoids this dependency entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)