### PR TITLE
fix(www): remove extra spacing above RESULT Instant REST API section

### DIFF
--- a/www/src/app/page.mdx
+++ b/www/src/app/page.mdx
@@ -321,12 +321,11 @@ const schema = {
 ```
 
 <div className="my-6 p-6 border border-green-200 dark:border-green-800 bg-green-50 dark:bg-green-900/20 rounded-xl">
-  <h3 className="text-lg font-semibold mb-4 flex items-center text-gray-900 dark:text-white">
+  <h3 className="text-lg font-semibold mb-2 flex items-center text-gray-900 dark:text-white">
     <span className="bg-green-100 dark:bg-green-900/30 text-green-800 dark:text-green-300 text-xs font-bold px-2 py-1 rounded mr-2">RESULT</span>
     Instant REST API
   </h3>
-  <pre className="text-sm text-gray-800 dark:text-gray-200 overflow-x-auto">
-{`// Auto-generated endpoints
+  <pre className="text-sm text-gray-800 dark:text-gray-200 overflow-x-auto m-0">{`// Auto-generated endpoints
 GET    /api/products
 GET    /api/products/:id
 POST   /api/products
@@ -334,8 +333,7 @@ PUT    /api/products/:id
 DELETE /api/products/:id
 
 // With filtering, sorting, pagination
-GET /api/products?category=electronics&sort=-price`}
-  </pre>
+GET /api/products?category=electronics&sort=-price`}</pre>
 </div>
 
 {/* Quick Start */}


### PR DESCRIPTION
## Summary
- Fixes extra `<p>` tag spacing above the "RESULT Instant REST API" section on homepage
- Reduces h3 margin from `mb-4` to `mb-2`
- Puts `<pre>` content on same line as tag to prevent MDX from inserting paragraph tags
- Adds `m-0` to `<pre>` to remove default margins

## Test plan
- [x] Verify spacing looks correct in the RESULT section
- [x] No extra whitespace above the pre block

🤖 Generated with [Claude Code](https://claude.com/claude-code)