### PR TITLE
remove AI slop of settings page documentation

### DIFF
--- a/docs/settings-page-overview.md
+++ b/docs/settings-page-overview.md
@@ -2,8 +2,6 @@
 
 ## Overview
 
-I've successfully created a comprehensive settings page with glass morphism design that integrates seamlessly with the existing SonicJS AI admin interface.
-
 ## Implementation Details
 
 ### Files Created/Modified


### PR DESCRIPTION
Removed introductory sentence about the settings page.

