### PR TITLE
security: add CSRF token protection (signed double-submit cookie)

### DIFF
--- a/packages/core/src/__tests__/middleware/csrf.test.ts
+++ b/packages/core/src/__tests__/middleware/csrf.test.ts
@@ -1,0 +1,525 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { Hono } from 'hono'
+import {
+  generateCsrfToken,
+  validateCsrfToken,
+  csrfProtection,
+  arrayBufferToBase64Url,
+} from '../../middleware/csrf'
+
+const TEST_SECRET = 'test-csrf-secret-for-unit-tests'
+const ALT_SECRET = 'different-secret-entirely'
+
+// ============================================================================
+// Token Generation & Validation
+// ============================================================================
+
+describe('generateCsrfToken', () => {
+  it('should generate a token in nonce.signature format', async () => {
+    const token = await generateCsrfToken(TEST_SECRET)
+    expect(token).toContain('.')
+    const parts = token.split('.')
+    expect(parts).toHaveLength(2)
+    expect(parts[0]!.length).toBeGreaterThan(0)
+    expect(parts[1]!.length).toBeGreaterThan(0)
+  })
+
+  it('should generate unique tokens on each call', async () => {
+    const token1 = await generateCsrfToken(TEST_SECRET)
+    const token2 = await generateCsrfToken(TEST_SECRET)
+    expect(token1).not.toBe(token2)
+  })
+})
+
+describe('validateCsrfToken', () => {
+  it('should validate a correctly signed token', async () => {
+    const token = await generateCsrfToken(TEST_SECRET)
+    const isValid = await validateCsrfToken(token, TEST_SECRET)
+    expect(isValid).toBe(true)
+  })
+
+  it('should reject a token signed with a different secret', async () => {
+    const token = await generateCsrfToken(TEST_SECRET)
+    const isValid = await validateCsrfToken(token, ALT_SECRET)
+    expect(isValid).toBe(false)
+  })
+
+  it('should reject a token with a tampered nonce', async () => {
+    const token = await generateCsrfToken(TEST_SECRET)
+    const [_nonce, signature] = token.split('.')
+    const tamperedToken = `tampered-nonce.${signature}`
+    const isValid = await validateCsrfToken(tamperedToken, TEST_SECRET)
+    expect(isValid).toBe(false)
+  })
+
+  it('should reject a token with a tampered signature', async () => {
+    const token = await generateCsrfToken(TEST_SECRET)
+    const [nonce, _signature] = token.split('.')
+    const tamperedToken = `${nonce}.tampered-signature-AAAA`
+    const isValid = await validateCsrfToken(tamperedToken, TEST_SECRET)
+    expect(isValid).toBe(false)
+  })
+
+  it('should reject an empty string', async () => {
+    const isValid = await validateCsrfToken('', TEST_SECRET)
+    expect(isValid).toBe(false)
+  })
+
+  it('should reject a token without a dot', async () => {
+    const isValid = await validateCsrfToken('nodothere', TEST_SECRET)
+    expect(isValid).toBe(false)
+  })
+
+  it('should reject null/undefined', async () => {
+    expect(await validateCsrfToken(null as any, TEST_SECRET)).toBe(false)
+    expect(await validateCsrfToken(undefined as any, TEST_SECRET)).toBe(false)
+  })
+})
+
+describe('arrayBufferToBase64Url', () => {
+  it('should produce url-safe base64 without padding', async () => {
+    const bytes = new Uint8Array([0, 255, 128, 64])
+    const result = arrayBufferToBase64Url(bytes.buffer)
+    expect(result).not.toContain('+')
+    expect(result).not.toContain('/')
+    expect(result).not.toContain('=')
+  })
+})
+
+// ============================================================================
+// Middleware Integration Tests
+// ============================================================================
+
+function createApp(opts?: { exemptPaths?: string[] }) {
+  const app = new Hono<{
+    Bindings: { JWT_SECRET?: string; ENVIRONMENT?: string }
+    Variables: { csrfToken?: string }
+  }>()
+
+  app.use('*', csrfProtection(opts))
+
+  // Test routes
+  app.get('/admin/dashboard', (c) => c.text('dashboard'))
+  app.post('/admin/content', (c) => c.text('created'))
+  app.put('/admin/content/1', (c) => c.text('updated'))
+  app.delete('/admin/content/1', (c) => c.text('deleted'))
+  app.patch('/admin/content/1', (c) => c.text('patched'))
+  app.post('/auth/login', (c) => c.text('login'))
+  app.post('/auth/login/form', (c) => c.text('login-form'))
+  app.post('/auth/register', (c) => c.text('register'))
+  app.post('/auth/register/form', (c) => c.text('register-form'))
+  app.post('/auth/seed-admin', (c) => c.text('seed'))
+  app.post('/auth/accept-invitation', (c) => c.text('accept'))
+  app.post('/auth/reset-password', (c) => c.text('reset'))
+  app.post('/forms/submit', (c) => c.text('form-submitted'))
+  app.post('/api/forms/submit', (c) => c.text('api-form-submitted'))
+  app.post('/admin/forms/save', (c) => c.text('admin-form-saved'))
+  app.post('/api/content', (c) => c.text('api-content'))
+  app.get('/api/content', (c) => c.text('api-list'))
+  app.post('/custom/exempt', (c) => c.text('custom-exempt'))
+
+  return app
+}
+
+// Helper to build request with env bindings
+function createReq(method: string, path: string, headers: Record<string, string> = {}) {
+  return new Request(`http://localhost${path}`, {
+    method,
+    headers,
+  })
+}
+
+describe('csrfProtection middleware', () => {
+  describe('safe methods', () => {
+    it('should allow GET requests through', async () => {
+      const app = createApp()
+      const res = await app.request('/admin/dashboard', {}, { JWT_SECRET: TEST_SECRET })
+      expect(res.status).toBe(200)
+    })
+
+    it('should set csrf_token cookie on GET when none exists', async () => {
+      const app = createApp()
+      const res = await app.request('/admin/dashboard', {}, { JWT_SECRET: TEST_SECRET })
+      expect(res.status).toBe(200)
+      const setCookieHeader = res.headers.get('set-cookie')
+      expect(setCookieHeader).toContain('csrf_token=')
+      expect(setCookieHeader).toContain('SameSite=Strict')
+      expect(setCookieHeader).toContain('Path=/')
+    })
+
+    it('should allow HEAD requests through', async () => {
+      const app = createApp()
+      const res = await app.request(
+        createReq('HEAD', '/admin/dashboard'),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      expect(res.status).toBe(200)
+    })
+
+    it('should allow OPTIONS requests through', async () => {
+      const app = createApp()
+      const res = await app.request(
+        createReq('OPTIONS', '/admin/dashboard'),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      // OPTIONS may return 404 since no explicit OPTIONS handler, but should not be 403
+      expect(res.status).not.toBe(403)
+    })
+  })
+
+  describe('reuse existing valid cookie', () => {
+    it('should NOT set a new cookie if existing csrf_token has valid HMAC', async () => {
+      const app = createApp()
+      const token = await generateCsrfToken(TEST_SECRET)
+      const res = await app.request(
+        createReq('GET', '/admin/dashboard', {
+          Cookie: `csrf_token=${token}`,
+        }),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      expect(res.status).toBe(200)
+      // Should NOT have a Set-Cookie for csrf_token since existing is valid
+      const setCookieHeader = res.headers.get('set-cookie')
+      expect(setCookieHeader).toBeNull()
+    })
+
+    it('should regenerate csrf_token when existing cookie has invalid HMAC', async () => {
+      const app = createApp()
+      const res = await app.request(
+        createReq('GET', '/admin/dashboard', {
+          Cookie: 'csrf_token=invalid-nonce.invalid-sig',
+        }),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      expect(res.status).toBe(200)
+      const setCookieHeader = res.headers.get('set-cookie')
+      expect(setCookieHeader).toContain('csrf_token=')
+    })
+  })
+
+  describe('state-changing requests with cookie auth', () => {
+    it('should allow POST with valid matching header + cookie', async () => {
+      const app = createApp()
+      const token = await generateCsrfToken(TEST_SECRET)
+      const res = await app.request(
+        createReq('POST', '/admin/content', {
+          Cookie: `auth_token=some-jwt; csrf_token=${token}`,
+          'X-CSRF-Token': token,
+        }),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      expect(res.status).toBe(200)
+      expect(await res.text()).toBe('created')
+    })
+
+    it('should reject POST with missing csrf_token cookie', async () => {
+      const app = createApp()
+      const token = await generateCsrfToken(TEST_SECRET)
+      const res = await app.request(
+        createReq('POST', '/admin/content', {
+          Cookie: 'auth_token=some-jwt',
+          'X-CSRF-Token': token,
+        }),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      expect(res.status).toBe(403)
+    })
+
+    it('should reject POST with missing X-CSRF-Token header', async () => {
+      const app = createApp()
+      const token = await generateCsrfToken(TEST_SECRET)
+      const res = await app.request(
+        createReq('POST', '/admin/content', {
+          Cookie: `auth_token=some-jwt; csrf_token=${token}`,
+        }),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      expect(res.status).toBe(403)
+    })
+
+    it('should reject POST with mismatched header and cookie', async () => {
+      const app = createApp()
+      const token1 = await generateCsrfToken(TEST_SECRET)
+      const token2 = await generateCsrfToken(TEST_SECRET)
+      const res = await app.request(
+        createReq('POST', '/admin/content', {
+          Cookie: `auth_token=some-jwt; csrf_token=${token1}`,
+          'X-CSRF-Token': token2,
+        }),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      expect(res.status).toBe(403)
+    })
+
+    it('should reject POST with invalid signature in token', async () => {
+      const app = createApp()
+      const res = await app.request(
+        createReq('POST', '/admin/content', {
+          Cookie: 'auth_token=some-jwt; csrf_token=fake-nonce.fake-sig',
+          'X-CSRF-Token': 'fake-nonce.fake-sig',
+        }),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      expect(res.status).toBe(403)
+    })
+
+    it('should validate PUT requests', async () => {
+      const app = createApp()
+      const token = await generateCsrfToken(TEST_SECRET)
+      const res = await app.request(
+        createReq('PUT', '/admin/content/1', {
+          Cookie: `auth_token=some-jwt; csrf_token=${token}`,
+          'X-CSRF-Token': token,
+        }),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      expect(res.status).toBe(200)
+    })
+
+    it('should validate DELETE requests', async () => {
+      const app = createApp()
+      const token = await generateCsrfToken(TEST_SECRET)
+      const res = await app.request(
+        createReq('DELETE', '/admin/content/1', {
+          Cookie: `auth_token=some-jwt; csrf_token=${token}`,
+          'X-CSRF-Token': token,
+        }),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      expect(res.status).toBe(200)
+    })
+
+    it('should validate PATCH requests', async () => {
+      const app = createApp()
+      const token = await generateCsrfToken(TEST_SECRET)
+      const res = await app.request(
+        createReq('PATCH', '/admin/content/1', {
+          Cookie: `auth_token=some-jwt; csrf_token=${token}`,
+          'X-CSRF-Token': token,
+        }),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      expect(res.status).toBe(200)
+    })
+  })
+
+  describe('exempt paths', () => {
+    it('should exempt /auth/login', async () => {
+      const app = createApp()
+      const res = await app.request(
+        createReq('POST', '/auth/login', {
+          Cookie: 'auth_token=some-jwt',
+        }),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      expect(res.status).toBe(200)
+    })
+
+    it('should exempt /auth/login/form', async () => {
+      const app = createApp()
+      const res = await app.request(
+        createReq('POST', '/auth/login/form', {
+          Cookie: 'auth_token=some-jwt',
+        }),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      expect(res.status).toBe(200)
+    })
+
+    it('should exempt /auth/register', async () => {
+      const app = createApp()
+      const res = await app.request(
+        createReq('POST', '/auth/register', {
+          Cookie: 'auth_token=some-jwt',
+        }),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      expect(res.status).toBe(200)
+    })
+
+    it('should exempt /auth/seed-admin', async () => {
+      const app = createApp()
+      const res = await app.request(
+        createReq('POST', '/auth/seed-admin', {
+          Cookie: 'auth_token=some-jwt',
+        }),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      expect(res.status).toBe(200)
+    })
+
+    it('should exempt /auth/accept-invitation', async () => {
+      const app = createApp()
+      const res = await app.request(
+        createReq('POST', '/auth/accept-invitation', {
+          Cookie: 'auth_token=some-jwt',
+        }),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      expect(res.status).toBe(200)
+    })
+
+    it('should exempt /auth/reset-password', async () => {
+      const app = createApp()
+      const res = await app.request(
+        createReq('POST', '/auth/reset-password', {
+          Cookie: 'auth_token=some-jwt',
+        }),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      expect(res.status).toBe(200)
+    })
+
+    it('should exempt /forms/* (public form submissions)', async () => {
+      const app = createApp()
+      const res = await app.request(
+        createReq('POST', '/forms/submit', {
+          Cookie: 'auth_token=some-jwt',
+        }),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      expect(res.status).toBe(200)
+    })
+
+    it('should exempt /api/forms/* (public API form submissions)', async () => {
+      const app = createApp()
+      const res = await app.request(
+        createReq('POST', '/api/forms/submit', {
+          Cookie: 'auth_token=some-jwt',
+        }),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      expect(res.status).toBe(200)
+    })
+
+    it('should NOT exempt /admin/forms/* (admin form management)', async () => {
+      const app = createApp()
+      const res = await app.request(
+        createReq('POST', '/admin/forms/save', {
+          Cookie: 'auth_token=some-jwt',
+        }),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      expect(res.status).toBe(403)
+    })
+
+    it('should accept custom exempt paths', async () => {
+      const app = createApp({ exemptPaths: ['/custom/exempt'] })
+      const res = await app.request(
+        createReq('POST', '/custom/exempt', {
+          Cookie: 'auth_token=some-jwt',
+        }),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      expect(res.status).toBe(200)
+    })
+  })
+
+  describe('Bearer-only / API-key-only exemption', () => {
+    it('should exempt requests with no auth_token cookie (Bearer-only)', async () => {
+      const app = createApp()
+      const res = await app.request(
+        createReq('POST', '/api/content', {
+          Authorization: 'Bearer some-jwt-token',
+        }),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      expect(res.status).toBe(200)
+    })
+
+    it('should exempt requests with no auth_token cookie (API-key-only)', async () => {
+      const app = createApp()
+      const res = await app.request(
+        createReq('POST', '/api/content', {
+          'X-API-Key': 'some-api-key',
+        }),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      expect(res.status).toBe(200)
+    })
+  })
+
+  describe('error responses', () => {
+    it('should return HTML error for browser requests (Accept: text/html)', async () => {
+      const app = createApp()
+      const res = await app.request(
+        createReq('POST', '/admin/content', {
+          Cookie: 'auth_token=some-jwt',
+          Accept: 'text/html,application/xhtml+xml',
+        }),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      expect(res.status).toBe(403)
+      const body = await res.text()
+      expect(body).toContain('403 Forbidden')
+      expect(body).toContain('CSRF token missing')
+    })
+
+    it('should return JSON error for API requests', async () => {
+      const app = createApp()
+      const res = await app.request(
+        createReq('POST', '/admin/content', {
+          Cookie: 'auth_token=some-jwt',
+          Accept: 'application/json',
+        }),
+        {},
+        { JWT_SECRET: TEST_SECRET }
+      )
+      expect(res.status).toBe(403)
+      const body = await res.json()
+      expect(body.error).toBe('CSRF token missing')
+      expect(body.status).toBe(403)
+    })
+  })
+
+  describe('JWT_SECRET fallback warning', () => {
+    it('should warn when JWT_SECRET is missing in production', async () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const app = createApp()
+
+      await app.request('/admin/dashboard', {}, { ENVIRONMENT: 'production' })
+
+      expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining('JWT_SECRET is not set in production')
+      )
+      consoleSpy.mockRestore()
+    })
+
+    it('should NOT warn in development mode', async () => {
+      const consoleSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const app = createApp()
+
+      await app.request('/admin/dashboard', {}, { ENVIRONMENT: 'development' })
+
+      expect(consoleSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('JWT_SECRET is not set in production')
+      )
+      consoleSpy.mockRestore()
+    })
+  })
+})

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -29,6 +29,7 @@ import {
 import { getCoreVersion } from './utils/version'
 import { bootstrapMiddleware } from './middleware/bootstrap'
 import { metricsMiddleware } from './middleware/metrics'
+import { csrfProtection } from './middleware/csrf'
 import { createDatabaseToolsAdminRoutes } from './plugins/core-plugins/database-tools-plugin/admin-routes'
 import { createSeedDataAdminRoutes } from './plugins/core-plugins/seed-data-plugin/admin-routes'
 import { emailPlugin } from './plugins/core-plugins/email-plugin'
@@ -68,6 +69,7 @@ export interface Variables {
   requestId?: string
   startTime?: number
   appVersion?: string
+  csrfToken?: string
 }
 
 export interface SonicJSConfig {
@@ -168,6 +170,9 @@ export function createSonicJSApp(config: SonicJSConfig = {}): SonicJSApp {
     // Security headers, CORS, etc.
     await next()
   })
+
+  // CSRF protection middleware
+  app.use('*', csrfProtection())
 
   // Custom middleware - after auth
   if (config.middleware?.afterAuth) {

--- a/packages/core/src/middleware/csrf.ts
+++ b/packages/core/src/middleware/csrf.ts
@@ -1,0 +1,281 @@
+/**
+ * CSRF Protection Middleware — Signed Double-Submit Cookie
+ *
+ * Stateless CSRF protection for Cloudflare Workers (no session store needed).
+ * Token format: `<nonce>.<hmac>` where HMAC-SHA256 is keyed with JWT_SECRET.
+ *
+ * Flow:
+ *   GET  — ensureCsrfCookie(): reuse existing valid cookie or set a new one
+ *   POST/PUT/DELETE/PATCH — validate X-CSRF-Token header === csrf_token cookie, HMAC valid
+ *
+ * Exempt:
+ *   - Safe methods (GET, HEAD, OPTIONS)
+ *   - Auth routes that create sessions (/auth/login*, /auth/register*, etc.)
+ *   - Public form submissions (/forms/*, /api/forms/*) — NOT /admin/forms/*
+ *   - Requests with no auth_token cookie (Bearer-only or API-key-only)
+ */
+
+import type { Context, Next } from 'hono'
+import { getCookie, setCookie } from 'hono/cookie'
+
+// Fallback secret — mirrors auth.ts behavior for local dev without wrangler secret
+const JWT_SECRET_FALLBACK = 'your-super-secret-jwt-key-change-in-production'
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+/** Convert ArrayBuffer to URL-safe base64 (no padding). */
+export function arrayBufferToBase64Url(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer)
+  let binary = ''
+  for (let i = 0; i < bytes.length; i++) {
+    binary += String.fromCharCode(bytes[i]!)
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+/** Import a string key for HMAC-SHA256. */
+async function getHmacKey(secret: string): Promise<CryptoKey> {
+  const encoder = new TextEncoder()
+  return crypto.subtle.importKey(
+    'raw',
+    encoder.encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign', 'verify']
+  )
+}
+
+// ============================================================================
+// Token Generation & Validation
+// ============================================================================
+
+/**
+ * Generate a signed CSRF token: `<nonce>.<hmac_signature>`
+ * - nonce = 32 random bytes, base64url-encoded
+ * - signature = HMAC-SHA256(nonce, secret), base64url-encoded
+ */
+export async function generateCsrfToken(secret: string): Promise<string> {
+  const nonceBytes = new Uint8Array(32)
+  crypto.getRandomValues(nonceBytes)
+  const nonce = arrayBufferToBase64Url(nonceBytes.buffer)
+
+  const key = await getHmacKey(secret)
+  const encoder = new TextEncoder()
+  const signatureBuffer = await crypto.subtle.sign('HMAC', key, encoder.encode(nonce))
+  const signature = arrayBufferToBase64Url(signatureBuffer)
+
+  return `${nonce}.${signature}`
+}
+
+/**
+ * Validate a signed CSRF token.
+ *
+ * Checks that the token has the correct `<nonce>.<signature>` format and that
+ * the HMAC signature is valid for the given secret. Uses crypto.subtle.verify
+ * which provides constant-time comparison.
+ *
+ * NOTE: No expiry check here — by design. The security property of signed
+ * double-submit comes from the unpredictability of the nonce + the
+ * secret-bound HMAC, not from time-bounding. The cookie's maxAge (86400s)
+ * handles expiry at the browser level.
+ */
+export async function validateCsrfToken(token: string, secret: string): Promise<boolean> {
+  if (!token || typeof token !== 'string') return false
+
+  const dotIndex = token.indexOf('.')
+  if (dotIndex === -1) return false
+
+  const nonce = token.substring(0, dotIndex)
+  const signature = token.substring(dotIndex + 1)
+
+  if (!nonce || !signature) return false
+
+  try {
+    const key = await getHmacKey(secret)
+    const encoder = new TextEncoder()
+
+    // Decode the signature from base64url
+    const sigPadded = signature.replace(/-/g, '+').replace(/_/g, '/')
+    const sigBinary = atob(sigPadded)
+    const sigBytes = new Uint8Array(sigBinary.length)
+    for (let i = 0; i < sigBinary.length; i++) {
+      sigBytes[i] = sigBinary.charCodeAt(i)
+    }
+
+    // crypto.subtle.verify is constant-time
+    return await crypto.subtle.verify('HMAC', key, sigBytes.buffer, encoder.encode(nonce))
+  } catch {
+    return false
+  }
+}
+
+// ============================================================================
+// Default Exempt Paths
+// ============================================================================
+
+const DEFAULT_EXEMPT_PATHS = [
+  '/auth/login',
+  '/auth/register',
+  '/auth/seed-admin',
+  '/auth/accept-invitation',
+  '/auth/reset-password',
+  '/auth/request-password-reset',
+]
+
+/**
+ * Check whether a request path is exempt from CSRF validation.
+ * - Exact match or startsWith for auth routes (e.g. /auth/login/form)
+ * - /forms/* and /api/forms/* are exempt (public submissions)
+ * - /api/search* is exempt (read-only POST for complex query params)
+ * - /admin/forms/* is NOT exempt
+ */
+function isExemptPath(path: string, extraExemptPaths: string[] = []): boolean {
+  // Public form routes — NOT /admin/forms/*
+  if (path.startsWith('/forms/') || path.startsWith('/api/forms/') || path === '/forms' || path === '/api/forms') {
+    return true
+  }
+
+  // Search API — read-only POST (includes /api/search/click, /api/search/facet-click)
+  if (path.startsWith('/api/search')) {
+    return true
+  }
+
+  const allExempt = [...DEFAULT_EXEMPT_PATHS, ...extraExemptPaths]
+  for (const exempt of allExempt) {
+    if (path === exempt || path.startsWith(exempt + '/')) {
+      return true
+    }
+  }
+
+  return false
+}
+
+// ============================================================================
+// Middleware
+// ============================================================================
+
+export interface CsrfOptions {
+  /** Additional paths to exempt from CSRF validation. */
+  exemptPaths?: string[]
+}
+
+/**
+ * CSRF protection middleware (Signed Double-Submit Cookie).
+ *
+ * - GET/HEAD/OPTIONS: ensure a valid csrf_token cookie exists
+ * - POST/PUT/DELETE/PATCH: validate X-CSRF-Token header matches cookie, HMAC valid
+ * - Exempt: auth routes, public /forms/*, Bearer-only, API-key-only
+ */
+export function csrfProtection(options: CsrfOptions = {}) {
+  return async (c: Context, next: Next): Promise<Response | void> => {
+    const method = c.req.method.toUpperCase()
+    const path = new URL(c.req.url).pathname
+    const secret = c.env?.JWT_SECRET || JWT_SECRET_FALLBACK
+
+    // Warn if using fallback secret in production
+    if (c.env?.ENVIRONMENT === 'production' && !c.env?.JWT_SECRET) {
+      console.warn(
+        '[CSRF] WARNING: JWT_SECRET is not set in production. ' +
+        'CSRF tokens are signed with the fallback key, which is insecure.'
+      )
+    }
+
+    // Safe methods — just ensure cookie, then pass through
+    if (method === 'GET' || method === 'HEAD' || method === 'OPTIONS') {
+      await ensureCsrfCookie(c, secret)
+      await next()
+      return
+    }
+
+    // Exempt paths — pass through without validation
+    if (isExemptPath(path, options.exemptPaths)) {
+      await next()
+      return
+    }
+
+    // Bearer-only or API-key-only requests (no auth_token cookie) — exempt
+    const authCookie = getCookie(c, 'auth_token')
+    if (!authCookie) {
+      await next()
+      return
+    }
+
+    // State-changing request with cookie auth — validate CSRF
+    const cookieToken = getCookie(c, 'csrf_token')
+    let headerToken = c.req.header('X-CSRF-Token')
+
+    // Fallback: check _csrf field in form-encoded body (regular HTML form submissions)
+    if (!headerToken) {
+      const contentType = c.req.header('Content-Type') || ''
+      if (contentType.includes('application/x-www-form-urlencoded') || contentType.includes('multipart/form-data')) {
+        try {
+          const body = await c.req.parseBody()
+          headerToken = body['_csrf'] as string | undefined
+        } catch {
+          // Body not parseable — leave headerToken undefined
+        }
+      }
+    }
+
+    if (!cookieToken || !headerToken) {
+      return csrfError(c, 'CSRF token missing')
+    }
+
+    if (cookieToken !== headerToken) {
+      return csrfError(c, 'CSRF token mismatch')
+    }
+
+    const isValid = await validateCsrfToken(cookieToken, secret)
+    if (!isValid) {
+      return csrfError(c, 'CSRF token invalid')
+    }
+
+    await next()
+  }
+}
+
+/**
+ * Ensure a valid CSRF cookie exists. Check-then-reuse: if the existing cookie
+ * has a valid HMAC signature, reuse it (no new Set-Cookie header). Only
+ * generate a fresh token when the cookie is missing or has an invalid signature.
+ */
+async function ensureCsrfCookie(c: Context, secret: string): Promise<void> {
+  const existing = getCookie(c, 'csrf_token')
+
+  if (existing) {
+    const isValid = await validateCsrfToken(existing, secret)
+    if (isValid) {
+      // Reuse existing valid token — no Set-Cookie needed
+      c.set('csrfToken', existing)
+      return
+    }
+  }
+
+  // Generate fresh token
+  const token = await generateCsrfToken(secret)
+  c.set('csrfToken', token)
+
+  const isDev = c.env?.ENVIRONMENT === 'development' || !c.env?.ENVIRONMENT
+  setCookie(c, 'csrf_token', token, {
+    httpOnly: false,  // JS must read this cookie
+    secure: !isDev,
+    sameSite: 'Strict',
+    path: '/',
+    maxAge: 86400,    // 24 hours — browser-side expiry
+  })
+}
+
+/** Return a 403 CSRF error — HTML for browser requests, JSON for API. */
+function csrfError(c: Context, message: string): Response {
+  const accept = c.req.header('Accept') || ''
+  if (accept.includes('text/html')) {
+    return c.html(
+      `<!DOCTYPE html><html><head><title>403 Forbidden</title></head>` +
+      `<body><h1>403 Forbidden</h1><p>${message}</p></body></html>`,
+      403
+    )
+  }
+  return c.json({ error: message, status: 403 }, 403)
+}

--- a/packages/core/src/middleware/index.ts
+++ b/packages/core/src/middleware/index.ts
@@ -16,6 +16,9 @@ export { AuthManager, requireAuth, requireRole, optionalAuth } from './auth'
 // Metrics middleware
 export { metricsMiddleware } from './metrics'
 
+// CSRF protection middleware
+export { csrfProtection, generateCsrfToken, validateCsrfToken } from './csrf'
+
 // Re-export types and functions that are referenced but implemented in monolith
 // These are placeholder exports to maintain API compatibility
 export type Permission = string

--- a/packages/core/src/routes/auth.ts
+++ b/packages/core/src/routes/auth.ts
@@ -3,13 +3,40 @@ import { Hono } from 'hono'
 import { z } from 'zod'
 import { setCookie } from 'hono/cookie'
 import { html } from 'hono/html'
-import { AuthManager, requireAuth } from '../middleware'
+import { AuthManager, requireAuth, generateCsrfToken } from '../middleware'
 import { renderLoginPage, LoginPageData } from '../templates/pages/auth-login.template'
 import { renderRegisterPage, RegisterPageData } from '../templates/pages/auth-register.template'
 import { getCacheService, CACHE_CONFIGS } from '../services'
 import { authValidationService, isRegistrationEnabled, isFirstUserRegistration } from '../services/auth-validation'
 import type { RegistrationData } from '../services/auth-validation'
 import type { Bindings, Variables } from '../app'
+
+const JWT_SECRET_FALLBACK = 'your-super-secret-jwt-key-change-in-production'
+
+/** Set a signed CSRF cookie alongside the auth cookie on login/register. */
+async function setCsrfCookie(c: any): Promise<void> {
+  const secret = c.env?.JWT_SECRET || JWT_SECRET_FALLBACK
+  const isDev = c.env?.ENVIRONMENT === 'development' || !c.env?.ENVIRONMENT
+  const csrfToken = await generateCsrfToken(secret)
+  setCookie(c, 'csrf_token', csrfToken, {
+    httpOnly: false,
+    secure: !isDev,
+    sameSite: 'Strict',
+    path: '/',
+    maxAge: 86400,
+  })
+}
+
+/** Clear the CSRF cookie on logout. */
+function clearCsrfCookie(c: any): void {
+  setCookie(c, 'csrf_token', '', {
+    httpOnly: false,
+    secure: false,
+    sameSite: 'Strict',
+    path: '/',
+    maxAge: 0,
+  })
+}
 
 const authRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>()
 
@@ -159,7 +186,10 @@ authRoutes.post('/register',
         sameSite: 'Strict',
         maxAge: 60 * 60 * 24 // 24 hours
       })
-      
+
+      // Set CSRF cookie for browser sessions
+      await setCsrfCookie(c)
+
       return c.json({
         user: {
           id: userId,
@@ -235,7 +265,10 @@ authRoutes.post('/login', async (c) => {
         sameSite: 'Strict',
         maxAge: 60 * 60 * 24 // 24 hours
       })
-      
+
+      // Set CSRF cookie for browser sessions
+      await setCsrfCookie(c)
+
       // Update last login
       await db.prepare('UPDATE users SET last_login_at = ? WHERE id = ?')
         .bind(new Date().getTime(), user.id)
@@ -271,7 +304,8 @@ authRoutes.post('/logout', (c) => {
     sameSite: 'Strict',
     maxAge: 0 // Expire immediately
   })
-  
+  clearCsrfCookie(c)
+
   return c.json({ message: 'Logged out successfully' })
 })
 
@@ -283,7 +317,8 @@ authRoutes.get('/logout', (c) => {
     sameSite: 'Strict',
     maxAge: 0 // Expire immediately
   })
-  
+  clearCsrfCookie(c)
+
   return c.redirect('/auth/login?message=You have been logged out successfully')
 })
 
@@ -332,7 +367,10 @@ authRoutes.post('/refresh', requireAuth(), async (c) => {
       sameSite: 'Strict',
       maxAge: 60 * 60 * 24 // 24 hours
     })
-    
+
+    // Set CSRF cookie for browser sessions
+    await setCsrfCookie(c)
+
     return c.json({ token })
   } catch (error) {
     console.error('Token refresh error:', error)
@@ -446,6 +484,9 @@ authRoutes.post('/register/form', async (c) => {
       maxAge: 60 * 60 * 24 // 24 hours
     })
 
+    // Set CSRF cookie for browser sessions
+    await setCsrfCookie(c)
+
     // Redirect based on role
     const redirectUrl = role === 'admin' ? '/admin/dashboard' : '/admin/dashboard'
 
@@ -525,7 +566,10 @@ authRoutes.post('/login/form', async (c) => {
       sameSite: 'Strict',
       maxAge: 60 * 60 * 24 // 24 hours
     })
-    
+
+    // Set CSRF cookie for browser sessions
+    await setCsrfCookie(c)
+
     // Update last login
     await db.prepare('UPDATE users SET last_login_at = ? WHERE id = ?')
       .bind(new Date().getTime(), user.id)
@@ -893,6 +937,9 @@ authRoutes.post('/accept-invitation', async (c) => {
       sameSite: 'Strict',
       maxAge: 60 * 60 * 24 // 24 hours
     })
+
+    // Set CSRF cookie for browser sessions
+    await setCsrfCookie(c)
 
     // Log the activity (TODO: implement activity logging)
     // Activity logging is deferred until utils/log-activity is implemented

--- a/packages/core/src/templates/components/form.template.ts
+++ b/packages/core/src/templates/components/form.template.ts
@@ -36,11 +36,12 @@ export interface FormData {
   title?: string
   description?: string
   className?: string
+  csrfToken?: string
 }
 
 export function renderForm(data: FormData): string {
   return `
-    <form 
+    <form
       ${data.id ? `id="${data.id}"` : ''}
       ${data.hxPost ? `hx-post="${data.hxPost}"` : data.hxPut ? `hx-put="${data.hxPut}"` : data.action ? `action="${data.action}"` : ''}
       ${data.hxTarget ? `hx-target="${data.hxTarget}"` : ''}
@@ -48,6 +49,7 @@ export function renderForm(data: FormData): string {
       class="${data.className || 'space-y-6'}"
       ${data.fields.some(f => f.type === 'file') ? 'enctype="multipart/form-data"' : ''}
     >
+      ${data.csrfToken ? `<input type="hidden" name="_csrf" value="${data.csrfToken}">` : ''}
       ${data.title ? `
         <div class="mb-6">
           <h2 class="text-lg font-medium text-gray-1">${data.title}</h2>

--- a/packages/core/src/templates/form.template.ts
+++ b/packages/core/src/templates/form.template.ts
@@ -36,6 +36,7 @@ export interface FormData {
   title?: string
   description?: string
   className?: string
+  csrfToken?: string
 }
 
 export function renderForm(data: FormData): string {
@@ -48,6 +49,7 @@ export function renderForm(data: FormData): string {
       class="${data.className || 'space-y-6'}"
       ${data.fields.some(f => f.type === 'file') ? 'enctype="multipart/form-data"' : ''}
     >
+      ${data.csrfToken ? `<input type="hidden" name="_csrf" value="${data.csrfToken}">` : ''}
       ${data.title ? `
         <div class="mb-6">
           <h2 class="text-lg font-medium text-gray-1">${data.title}</h2>

--- a/packages/core/src/templates/layouts/admin-layout-catalyst.template.ts
+++ b/packages/core/src/templates/layouts/admin-layout-catalyst.template.ts
@@ -249,6 +249,58 @@ export function renderAdminLayoutCatalyst(
   <script src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js" defer></script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
 
+  <!-- CSRF: Auto-attach token to all HTMX and fetch requests -->
+  <script>
+    function getCsrfToken() {
+      var cookie = document.cookie.split('; ')
+        .find(function(row) { return row.startsWith('csrf_token='); });
+      return cookie ? cookie.substring(cookie.indexOf('=') + 1) : '';
+    }
+
+    document.addEventListener('htmx:configRequest', function(event) {
+      var token = getCsrfToken();
+      if (token) {
+        event.detail.headers['X-CSRF-Token'] = token;
+      }
+    });
+
+    (function() {
+      var originalFetch = window.fetch;
+      window.fetch = function(url, options) {
+        options = options || {};
+        var method = (options.method || 'GET').toUpperCase();
+        if (method !== 'GET' && method !== 'HEAD' && method !== 'OPTIONS') {
+          options.headers = options.headers || {};
+          if (options.headers instanceof Headers) {
+            if (!options.headers.has('X-CSRF-Token')) {
+              options.headers.set('X-CSRF-Token', getCsrfToken());
+            }
+          } else if (!Array.isArray(options.headers) && !options.headers['X-CSRF-Token']) {
+            options.headers['X-CSRF-Token'] = getCsrfToken();
+          }
+        }
+        return originalFetch.call(this, url, options);
+      };
+    })();
+
+    // Inject _csrf hidden field into regular form submissions (non-HTMX)
+    document.addEventListener('submit', function(event) {
+      var form = event.target;
+      if (!form || !form.tagName || form.tagName !== 'FORM') return;
+      var method = (form.method || 'GET').toUpperCase();
+      if (method === 'GET') return;
+      if (form.hasAttribute('hx-post') || form.hasAttribute('hx-put') ||
+          form.hasAttribute('hx-delete') || form.hasAttribute('hx-patch')) return;
+      if (!form.querySelector('input[name="_csrf"]')) {
+        var input = document.createElement('input');
+        input.type = 'hidden';
+        input.name = '_csrf';
+        input.value = getCsrfToken();
+        form.appendChild(input);
+      }
+    });
+  </script>
+
   ${
     data.styles
       ? data.styles

--- a/tests/e2e/02b-authentication-api.spec.ts
+++ b/tests/e2e/02b-authentication-api.spec.ts
@@ -1,5 +1,16 @@
 import { test, expect } from '@playwright/test';
-import { ADMIN_CREDENTIALS } from './utils/test-helpers';
+import { ADMIN_CREDENTIALS, extractCsrfToken } from './utils/test-helpers';
+
+/**
+ * Check if a registration response indicates registration is disabled
+ * by a concurrent test shard (37-disable-registration.spec.ts).
+ * Returns true if the test should be skipped.
+ */
+function isRegistrationDisabled(status: number, body: any): boolean {
+  if (status !== 403) return false;
+  const msg = body?.error || '';
+  return msg.includes('disabled') || msg.includes('Registration');
+}
 
 test.describe('Authentication API', () => {
   const testUser = {
@@ -10,12 +21,30 @@ test.describe('Authentication API', () => {
     lastName: 'User'
   };
 
-  // Seed admin user before all tests
+  // Seed admin user and ensure registration is enabled before all tests
   test.beforeAll(async ({ request }) => {
     try {
       await request.post('/auth/seed-admin');
     } catch (error) {
       // Admin might already exist, ignore errors
+    }
+
+    // Ensure registration is enabled (may have been disabled by 37-disable-registration tests)
+    try {
+      const loginRes = await request.post('/auth/login', {
+        data: { email: ADMIN_CREDENTIALS.email, password: ADMIN_CREDENTIALS.password }
+      });
+      if (loginRes.ok()) {
+        const { token } = await loginRes.json();
+        await request.post('/admin/plugins/core-auth/settings', {
+          headers: { Authorization: `Bearer ${token}` },
+          data: {
+            registration: { enabled: true, requireEmailVerification: false, defaultRole: 'viewer' }
+          }
+        });
+      }
+    } catch (error) {
+      // Best effort — tests will fail with clear 403 if this didn't work
     }
   });
 
@@ -37,12 +66,13 @@ test.describe('Authentication API', () => {
         data: uniqueUser
       });
 
-      expect(response.status()).toBe(201);
-      
       const data = await response.json();
+      if (isRegistrationDisabled(response.status(), data)) return;
+
+      expect(response.status()).toBe(201);
       expect(data).toHaveProperty('user');
       expect(data).toHaveProperty('token');
-      
+
       // Verify user object
       expect(data.user).toMatchObject({
         email: uniqueUser.email.toLowerCase(),
@@ -51,10 +81,10 @@ test.describe('Authentication API', () => {
         lastName: uniqueUser.lastName,
         role: 'viewer'
       });
-      
+
       // Should have a valid UUID
       expect(data.user.id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
-      
+
       // Should have a JWT token
       expect(data.token).toBeTruthy();
       expect(data.token.split('.')).toHaveLength(3); // JWT format
@@ -71,9 +101,10 @@ test.describe('Authentication API', () => {
         data: uniqueUser
       });
 
-      expect(response.status()).toBe(201);
-      
       const data = await response.json();
+      if (isRegistrationDisabled(response.status(), data)) return;
+
+      expect(response.status()).toBe(201);
       expect(data.user.email).toBe(uniqueUser.email.toLowerCase());
     });
 
@@ -112,6 +143,8 @@ test.describe('Authentication API', () => {
       const firstResponse = await request.post('/auth/register', {
         data: uniqueUser
       });
+      const firstData = await firstResponse.json();
+      if (isRegistrationDisabled(firstResponse.status(), firstData)) return;
       expect(firstResponse.status()).toBe(201);
 
       // Second registration with same email should fail
@@ -123,7 +156,7 @@ test.describe('Authentication API', () => {
       });
 
       expect(secondResponse.status()).toBe(400);
-      
+
       const data = await secondResponse.json();
       expect(data.error).toContain('already exists');
     });
@@ -139,6 +172,8 @@ test.describe('Authentication API', () => {
       const firstResponse = await request.post('/auth/register', {
         data: uniqueUser
       });
+      const firstData = await firstResponse.json();
+      if (isRegistrationDisabled(firstResponse.status(), firstData)) return;
       expect(firstResponse.status()).toBe(201);
 
       // Second registration with same username should fail
@@ -150,7 +185,7 @@ test.describe('Authentication API', () => {
       });
 
       expect(secondResponse.status()).toBe(400);
-      
+
       const data = await secondResponse.json();
       expect(data.error).toContain('already exists');
     });
@@ -166,8 +201,13 @@ test.describe('Authentication API', () => {
         data: uniqueUser
       });
 
+      if (response.status() === 403) {
+        const body = await response.json();
+        if (isRegistrationDisabled(response.status(), body)) return;
+      }
+
       expect(response.status()).toBe(201);
-      
+
       // Check for auth cookie
       const cookies = response.headers()['set-cookie'];
       expect(cookies).toBeTruthy();
@@ -187,9 +227,10 @@ test.describe('Authentication API', () => {
         data: uniqueUser
       });
 
-      expect(response.status()).toBe(201);
-      
       const data = await response.json();
+      if (isRegistrationDisabled(response.status(), data)) return;
+
+      expect(response.status()).toBe(201);
       expect(data.user.role).toBe('viewer');
     });
   });
@@ -337,14 +378,16 @@ test.describe('Authentication API', () => {
       });
       expect(loginResponse.status()).toBe(200);
 
-      // Extract auth cookie
+      // Extract auth cookie and CSRF token
       const cookies = loginResponse.headers()['set-cookie'];
       const authCookie = cookies?.split(';')[0] || '';
+      const csrfToken = extractCsrfToken(cookies);
 
       // Logout with the session
       const logoutResponse = await request.post('/auth/logout', {
         headers: {
-          'Cookie': authCookie
+          'Cookie': `${authCookie}; csrf_token=${csrfToken}`,
+          'X-CSRF-Token': csrfToken
         }
       });
 
@@ -440,9 +483,10 @@ test.describe('Authentication API', () => {
       const loginData = await loginResponse.json();
       const originalToken = loginData.token;
 
-      // Extract auth cookie
+      // Extract auth cookie and CSRF token
       const cookies = loginResponse.headers()['set-cookie'];
       const authCookie = cookies?.split(';')[0] || '';
+      const csrfToken = extractCsrfToken(cookies);
 
       // Wait a moment to ensure different timestamp
       await new Promise(resolve => setTimeout(resolve, 1100));
@@ -450,7 +494,8 @@ test.describe('Authentication API', () => {
       // Refresh token
       const refreshResponse = await request.post('/auth/refresh', {
         headers: {
-          'Cookie': authCookie
+          'Cookie': `${authCookie}; csrf_token=${csrfToken}`,
+          'X-CSRF-Token': csrfToken
         }
       });
 
@@ -493,15 +538,16 @@ test.describe('Authentication API', () => {
         data: uniqueUser
       });
 
-      expect(response.status()).toBe(201);
-      
       const data = await response.json();
-      
+      if (isRegistrationDisabled(response.status(), data)) return;
+
+      expect(response.status()).toBe(201);
+
       // Should not expose password or hash
       expect(data.user).not.toHaveProperty('password');
       expect(data.user).not.toHaveProperty('password_hash');
       expect(data.user).not.toHaveProperty('passwordHash');
-      
+
       // Response should not contain the original password
       const responseText = JSON.stringify(data);
       expect(responseText).not.toContain(uniqueUser.password);
@@ -660,11 +706,13 @@ test.describe('Authentication API', () => {
 
       const cookies = loginResponse.headers()['set-cookie'];
       const authCookie = cookies?.split(';')[0] || '';
+      const csrfToken = extractCsrfToken(cookies);
+      const fullCookie = `${authCookie}; csrf_token=${csrfToken}`;
 
       // Make authenticated request
       const meResponse = await request.get('/auth/me', {
         headers: {
-          'Cookie': authCookie
+          'Cookie': fullCookie
         }
       });
       expect(meResponse.status()).toBe(200);
@@ -672,7 +720,8 @@ test.describe('Authentication API', () => {
       // Make another authenticated request
       const refreshResponse = await request.post('/auth/refresh', {
         headers: {
-          'Cookie': authCookie
+          'Cookie': fullCookie,
+          'X-CSRF-Token': csrfToken
         }
       });
       expect(refreshResponse.status()).toBe(200);

--- a/tests/e2e/08b-admin-collections-api.spec.ts
+++ b/tests/e2e/08b-admin-collections-api.spec.ts
@@ -10,12 +10,14 @@ test.describe('Admin Collections API', () => {
     const page = await context.newPage();
     await loginAsAdmin(page);
     
-    // Extract auth cookies for API requests
+    // Extract auth cookies and CSRF token for API requests
     const cookies = await context.cookies();
     const cookieHeader = cookies.map(c => `${c.name}=${c.value}`).join('; ');
+    const csrfCookie = cookies.find(c => c.name === 'csrf_token');
     authHeaders = {
       'Cookie': cookieHeader,
-      'Content-Type': 'application/json'
+      'Content-Type': 'application/json',
+      ...(csrfCookie ? { 'X-CSRF-Token': csrfCookie.value } : {})
     };
     
     await context.close();

--- a/tests/e2e/13-migrations.spec.ts
+++ b/tests/e2e/13-migrations.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { loginAsAdmin } from './utils/test-helpers';
+import { loginAsAdmin, getCsrfTokenFromPage } from './utils/test-helpers';
 
 test.describe.skip('Admin Migrations Page', () => {
   test.beforeEach(async ({ page }) => {
@@ -325,7 +325,10 @@ test.describe('Migrations API Endpoints', () => {
 
   test('should require admin role for run migrations endpoint', async ({ page }) => {
     // This test verifies that the endpoint properly checks admin permissions
-    const response = await page.request.post('/admin/api/migrations/run');
+    const csrfToken = await getCsrfTokenFromPage(page);
+    const response = await page.request.post('/admin/api/migrations/run', {
+      headers: { ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) }
+    });
     
     // Should either succeed (if user is admin) or return 403
     expect([200, 403]).toContain(response.status());

--- a/tests/e2e/14-database-tools.spec.ts
+++ b/tests/e2e/14-database-tools.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { loginAsAdmin } from './utils/test-helpers';
+import { loginAsAdmin, getCsrfTokenFromPage } from './utils/test-helpers';
 
 test.describe.skip('Database Tools', () => {
   test.beforeEach(async ({ page }) => {
@@ -342,7 +342,10 @@ test.describe('Database Tools API Endpoints', () => {
   });
 
   test('should require admin role for backup endpoint', async ({ page }) => {
-    const response = await page.request.post('/admin/database-tools/api/backup');
+    const csrfToken = await getCsrfTokenFromPage(page);
+    const response = await page.request.post('/admin/database-tools/api/backup', {
+      headers: { ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) }
+    });
     
     // Should either succeed (if user is admin) or return 403
     expect([200, 403]).toContain(response.status());
@@ -358,7 +361,9 @@ test.describe('Database Tools API Endpoints', () => {
   });
 
   test('should require admin role for truncate endpoint', async ({ page }) => {
+    const csrfToken = await getCsrfTokenFromPage(page);
     const response = await page.request.post('/admin/database-tools/api/truncate', {
+      headers: { ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) },
       data: { confirmText: 'TRUNCATE ALL DATA' }
     });
     

--- a/tests/e2e/23-content-api-crud.spec.ts
+++ b/tests/e2e/23-content-api-crud.spec.ts
@@ -7,6 +7,7 @@ const BASE_URL = process.env.BASE_URL || 'http://localhost:8787';
 let testCollectionId: string;
 let testContentId: string;
 let authToken: string;
+let csrfToken: string;
 
 test.describe('Content API CRUD Operations', () => {
   test.beforeAll(async ({ browser }) => {
@@ -22,6 +23,10 @@ test.describe('Content API CRUD Operations', () => {
     const authCookie = cookies.find(c => c.name === 'auth_token' || c.name === 'token');
     if (authCookie) {
       authToken = authCookie.value;
+    }
+    const csrfCookie = cookies.find(c => c.name === 'csrf_token');
+    if (csrfCookie) {
+      csrfToken = csrfCookie.value;
     }
 
     await context.close();
@@ -56,7 +61,7 @@ test.describe('Content API CRUD Operations', () => {
         data: newContent,
         headers: {
           'Content-Type': 'application/json',
-          ...(authToken ? { 'Cookie': `auth_token=${authToken}` } : {})
+          ...(authToken ? { 'Cookie': `auth_token=${authToken}${csrfToken ? `; csrf_token=${csrfToken}` : ''}`, ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) } : {})
         }
       });
 
@@ -114,7 +119,7 @@ test.describe('Content API CRUD Operations', () => {
         data: invalidContent,
         headers: {
           'Content-Type': 'application/json',
-          ...(authToken ? { 'Cookie': `auth_token=${authToken}` } : {})
+          ...(authToken ? { 'Cookie': `auth_token=${authToken}${csrfToken ? `; csrf_token=${csrfToken}` : ''}`, ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) } : {})
         }
       });
 
@@ -138,7 +143,7 @@ test.describe('Content API CRUD Operations', () => {
         data: newContent,
         headers: {
           'Content-Type': 'application/json',
-          ...(authToken ? { 'Cookie': `auth_token=${authToken}` } : {})
+          ...(authToken ? { 'Cookie': `auth_token=${authToken}${csrfToken ? `; csrf_token=${csrfToken}` : ''}`, ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) } : {})
         }
       });
 
@@ -154,7 +159,7 @@ test.describe('Content API CRUD Operations', () => {
         // Cleanup
         if (responseData.data.id) {
           await request.delete(`${BASE_URL}/api/content/${responseData.data.id}`, {
-            headers: { ...(authToken ? { 'Cookie': `auth_token=${authToken}` } : {}) }
+            headers: { ...(authToken ? { 'Cookie': `auth_token=${authToken}${csrfToken ? `; csrf_token=${csrfToken}` : ''}`, ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) } : {}) }
           });
         }
       }
@@ -175,7 +180,7 @@ test.describe('Content API CRUD Operations', () => {
         data: firstContent,
         headers: {
           'Content-Type': 'application/json',
-          ...(authToken ? { 'Cookie': `auth_token=${authToken}` } : {})
+          ...(authToken ? { 'Cookie': `auth_token=${authToken}${csrfToken ? `; csrf_token=${csrfToken}` : ''}`, ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) } : {})
         }
       });
 
@@ -199,7 +204,7 @@ test.describe('Content API CRUD Operations', () => {
         data: secondContent,
         headers: {
           'Content-Type': 'application/json',
-          ...(authToken ? { 'Cookie': `auth_token=${authToken}` } : {})
+          ...(authToken ? { 'Cookie': `auth_token=${authToken}${csrfToken ? `; csrf_token=${csrfToken}` : ''}`, ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) } : {})
         }
       });
 
@@ -211,7 +216,7 @@ test.describe('Content API CRUD Operations', () => {
 
       // Cleanup
       await request.delete(`${BASE_URL}/api/content/${firstId}`, {
-        headers: { ...(authToken ? { 'Cookie': `auth_token=${authToken}` } : {}) }
+        headers: { ...(authToken ? { 'Cookie': `auth_token=${authToken}${csrfToken ? `; csrf_token=${csrfToken}` : ''}`, ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) } : {}) }
       });
     });
   });
@@ -235,7 +240,7 @@ test.describe('Content API CRUD Operations', () => {
         data: newContent,
         headers: {
           'Content-Type': 'application/json',
-          ...(authToken ? { 'Cookie': `auth_token=${authToken}` } : {})
+          ...(authToken ? { 'Cookie': `auth_token=${authToken}${csrfToken ? `; csrf_token=${csrfToken}` : ''}`, ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) } : {})
         }
       });
 
@@ -250,7 +255,7 @@ test.describe('Content API CRUD Operations', () => {
       // Cleanup
       if (contentToUpdate) {
         await request.delete(`${BASE_URL}/api/content/${contentToUpdate}`, {
-          headers: { ...(authToken ? { 'Cookie': `auth_token=${authToken}` } : {}) }
+          headers: { ...(authToken ? { 'Cookie': `auth_token=${authToken}${csrfToken ? `; csrf_token=${csrfToken}` : ''}`, ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) } : {}) }
         });
       }
     });
@@ -274,7 +279,7 @@ test.describe('Content API CRUD Operations', () => {
         data: updates,
         headers: {
           'Content-Type': 'application/json',
-          ...(authToken ? { 'Cookie': `auth_token=${authToken}` } : {})
+          ...(authToken ? { 'Cookie': `auth_token=${authToken}${csrfToken ? `; csrf_token=${csrfToken}` : ''}`, ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) } : {})
         }
       });
 
@@ -303,7 +308,7 @@ test.describe('Content API CRUD Operations', () => {
         data: { title: 'Updated' },
         headers: {
           'Content-Type': 'application/json',
-          ...(authToken ? { 'Cookie': `auth_token=${authToken}` } : {})
+          ...(authToken ? { 'Cookie': `auth_token=${authToken}${csrfToken ? `; csrf_token=${csrfToken}` : ''}`, ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) } : {})
         }
       });
 
@@ -347,7 +352,7 @@ test.describe('Content API CRUD Operations', () => {
         data: updates,
         headers: {
           'Content-Type': 'application/json',
-          ...(authToken ? { 'Cookie': `auth_token=${authToken}` } : {})
+          ...(authToken ? { 'Cookie': `auth_token=${authToken}${csrfToken ? `; csrf_token=${csrfToken}` : ''}`, ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) } : {})
         }
       });
 
@@ -380,7 +385,7 @@ test.describe('Content API CRUD Operations', () => {
         data: newContent,
         headers: {
           'Content-Type': 'application/json',
-          ...(authToken ? { 'Cookie': `auth_token=${authToken}` } : {})
+          ...(authToken ? { 'Cookie': `auth_token=${authToken}${csrfToken ? `; csrf_token=${csrfToken}` : ''}`, ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) } : {})
         }
       });
 
@@ -399,7 +404,7 @@ test.describe('Content API CRUD Operations', () => {
 
       const response = await request.delete(`${BASE_URL}/api/content/${contentToDelete}`, {
         headers: {
-          ...(authToken ? { 'Cookie': `auth_token=${authToken}` } : {})
+          ...(authToken ? { 'Cookie': `auth_token=${authToken}${csrfToken ? `; csrf_token=${csrfToken}` : ''}`, ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) } : {})
         }
       });
 
@@ -430,7 +435,7 @@ test.describe('Content API CRUD Operations', () => {
 
       const response = await request.delete(`${BASE_URL}/api/content/${fakeId}`, {
         headers: {
-          ...(authToken ? { 'Cookie': `auth_token=${authToken}` } : {})
+          ...(authToken ? { 'Cookie': `auth_token=${authToken}${csrfToken ? `; csrf_token=${csrfToken}` : ''}`, ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) } : {})
         }
       });
 
@@ -457,7 +462,7 @@ test.describe('Content API CRUD Operations', () => {
       // Cleanup if delete test failed
       if (contentToDelete) {
         await request.delete(`${BASE_URL}/api/content/${contentToDelete}`, {
-          headers: { ...(authToken ? { 'Cookie': `auth_token=${authToken}` } : {}) }
+          headers: { ...(authToken ? { 'Cookie': `auth_token=${authToken}${csrfToken ? `; csrf_token=${csrfToken}` : ''}`, ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) } : {}) }
         }).catch(() => {});
       }
     });
@@ -480,7 +485,7 @@ test.describe('Content API CRUD Operations', () => {
         data: newContent,
         headers: {
           'Content-Type': 'application/json',
-          ...(authToken ? { 'Cookie': `auth_token=${authToken}` } : {})
+          ...(authToken ? { 'Cookie': `auth_token=${authToken}${csrfToken ? `; csrf_token=${csrfToken}` : ''}`, ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) } : {})
         }
       });
 
@@ -508,7 +513,7 @@ test.describe('Content API CRUD Operations', () => {
         },
         headers: {
           'Content-Type': 'application/json',
-          ...(authToken ? { 'Cookie': `auth_token=${authToken}` } : {})
+          ...(authToken ? { 'Cookie': `auth_token=${authToken}${csrfToken ? `; csrf_token=${csrfToken}` : ''}`, ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) } : {})
         }
       });
 
@@ -521,7 +526,7 @@ test.describe('Content API CRUD Operations', () => {
       // DELETE
       const deleteResponse = await request.delete(`${BASE_URL}/api/content/${contentId}`, {
         headers: {
-          ...(authToken ? { 'Cookie': `auth_token=${authToken}` } : {})
+          ...(authToken ? { 'Cookie': `auth_token=${authToken}${csrfToken ? `; csrf_token=${csrfToken}` : ''}`, ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {}) } : {})
         }
       });
 

--- a/tests/e2e/utils/test-helpers.ts
+++ b/tests/e2e/utils/test-helpers.ts
@@ -29,6 +29,26 @@ export const TEST_DATA = {
 };
 
 /**
+ * Extract CSRF token value from Set-Cookie response header.
+ * Works with Playwright's newline-joined Set-Cookie format.
+ */
+export function extractCsrfToken(setCookieHeader: string | undefined): string {
+  if (!setCookieHeader) return '';
+  const match = setCookieHeader.match(/csrf_token=([^;\s]+)/);
+  return match ? match[1] : '';
+}
+
+/**
+ * Get CSRF token from page context cookies.
+ * Use with page.request.post() calls that need CSRF headers.
+ */
+export async function getCsrfTokenFromPage(page: Page): Promise<string> {
+  const cookies = await page.context().cookies();
+  const csrfCookie = cookies.find(c => c.name === 'csrf_token');
+  return csrfCookie?.value || '';
+}
+
+/**
  * Ensure admin user exists (for testing)
  */
 export async function ensureAdminUserExists(page: Page) {
@@ -46,9 +66,11 @@ export async function ensureAdminUserExists(page: Page) {
 export async function ensureWorkflowTablesExist(page: Page) {
   try {
     // Make an authenticated request using the page's cookies
+    const csrfToken = await getCsrfTokenFromPage(page);
     const response = await page.request.post('/admin/api/migrations/run', {
       headers: {
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        ...(csrfToken ? { 'X-CSRF-Token': csrfToken } : {})
       }
     });
 
@@ -368,6 +390,23 @@ export async function loginAsAdmin(page: Page) {
   // Navigate back to admin dashboard after plugin setup
   await page.goto('/admin');
   await page.waitForLoadState('networkidle', { timeout: 15000 });
+
+  // Auto-attach CSRF token to all state-changing page.request calls
+  const csrfToken = await getCsrfTokenFromPage(page);
+  if (csrfToken) {
+    const addCsrf = (opts?: any) => ({
+      ...opts,
+      headers: { ...(opts?.headers || {}), 'X-CSRF-Token': csrfToken }
+    });
+    const origPost = page.request.post.bind(page.request);
+    const origPut = page.request.put.bind(page.request);
+    const origDelete = page.request.delete.bind(page.request);
+    const origPatch = page.request.patch.bind(page.request);
+    (page.request as any).post = (url: string, opts?: any) => origPost(url, addCsrf(opts));
+    (page.request as any).put = (url: string, opts?: any) => origPut(url, addCsrf(opts));
+    (page.request as any).delete = (url: string, opts?: any) => origDelete(url, addCsrf(opts));
+    (page.request as any).patch = (url: string, opts?: any) => origPatch(url, addCsrf(opts));
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary
Cherry-picked from #668 by @mmcintosh

Adds CSRF token protection using a signed double-submit cookie pattern to protect against cross-site request forgery attacks.

---
## Attribution
- Original PR: #668
- Original Author: @mmcintosh (Mark McIntosh)

Closes #668

🤖 Generated with [Claude Code](https://claude.com/claude-code)