### PR TITLE
security: move JWT secret to environment variable

### DIFF
--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -54,6 +54,7 @@ export interface Bindings {
   IMAGES_ACCOUNT_ID?: string
   IMAGES_API_TOKEN?: string
   ENVIRONMENT?: string
+  JWT_SECRET?: string
   BUCKET_NAME?: string
   GOOGLE_MAPS_API_KEY?: string
 }

--- a/packages/core/src/middleware/auth.ts
+++ b/packages/core/src/middleware/auth.ts
@@ -10,11 +10,11 @@ type JWTPayload = {
   iat: number
 }
 
-// JWT secret - in production this should come from environment variables
-const JWT_SECRET = 'your-super-secret-jwt-key-change-in-production'
+// Fallback JWT secret for local development only (no wrangler secret set)
+const JWT_SECRET_FALLBACK = 'your-super-secret-jwt-key-change-in-production'
 
 export class AuthManager {
-  static async generateToken(userId: string, email: string, role: string): Promise<string> {
+  static async generateToken(userId: string, email: string, role: string, secret?: string): Promise<string> {
     const payload: JWTPayload = {
       userId,
       email,
@@ -22,13 +22,13 @@ export class AuthManager {
       exp: Math.floor(Date.now() / 1000) + (60 * 60 * 24), // 24 hours
       iat: Math.floor(Date.now() / 1000)
     }
-    
-    return await sign(payload, JWT_SECRET, 'HS256')
+
+    return await sign(payload, secret || JWT_SECRET_FALLBACK, 'HS256')
   }
 
-  static async verifyToken(token: string): Promise<JWTPayload | null> {
+  static async verifyToken(token: string, secret?: string): Promise<JWTPayload | null> {
     try {
-      const payload = await verify(token, JWT_SECRET, 'HS256') as JWTPayload
+      const payload = await verify(token, secret || JWT_SECRET_FALLBACK, 'HS256') as JWTPayload
       
       // Check if token is expired
       if (payload.exp < Math.floor(Date.now() / 1000)) {
@@ -112,7 +112,8 @@ export const requireAuth = () => {
 
       // If not cached, verify token
       if (!payload) {
-        payload = await AuthManager.verifyToken(token)
+        const jwtSecret = (c.env as any)?.JWT_SECRET
+        payload = await AuthManager.verifyToken(token, jwtSecret)
 
         // Cache the verified payload for 5 minutes
         if (payload && kv) {
@@ -186,7 +187,8 @@ export const optionalAuth = () => {
       }
       
       if (token) {
-        const payload = await AuthManager.verifyToken(token)
+        const jwtSecret = (c.env as any)?.JWT_SECRET
+        const payload = await AuthManager.verifyToken(token, jwtSecret)
         if (payload) {
           c.set('user', payload)
         }

--- a/packages/core/src/plugins/available/magic-link-auth/index.ts
+++ b/packages/core/src/plugins/available/magic-link-auth/index.ts
@@ -204,7 +204,8 @@ export function createMagicLinkAuthPlugin(): Plugin {
       const jwtToken = await AuthManager.generateToken(
         user.id,
         user.email,
-        user.role
+        user.role,
+        (c.env as any).JWT_SECRET
       )
 
       // Set auth cookie

--- a/packages/core/src/plugins/core-plugins/otp-login-plugin/index.ts
+++ b/packages/core/src/plugins/core-plugins/otp-login-plugin/index.ts
@@ -282,7 +282,7 @@ export function createOTPLoginPlugin(): Plugin {
       }
 
       // Generate JWT token
-      const token = await AuthManager.generateToken(user.id, user.email, user.role)
+      const token = await AuthManager.generateToken(user.id, user.email, user.role, (c.env as any).JWT_SECRET)
 
       // Set HTTP-only cookie
       setCookie(c, 'auth_token', token, {

--- a/packages/core/src/routes/auth.ts
+++ b/packages/core/src/routes/auth.ts
@@ -177,7 +177,7 @@ authRoutes.post('/register',
       ).run()
       
       // Generate JWT token
-      const token = await AuthManager.generateToken(userId, normalizedEmail, 'viewer')
+      const token = await AuthManager.generateToken(userId, normalizedEmail, 'viewer', c.env.JWT_SECRET)
       
       // Set HTTP-only cookie
       setCookie(c, 'auth_token', token, {
@@ -256,8 +256,8 @@ authRoutes.post('/login', async (c) => {
       }
       
       // Generate JWT token
-      const token = await AuthManager.generateToken(user.id, user.email, user.role)
-      
+      const token = await AuthManager.generateToken(user.id, user.email, user.role, c.env.JWT_SECRET)
+
       // Set HTTP-only cookie
       setCookie(c, 'auth_token', token, {
         httpOnly: true,
@@ -358,7 +358,7 @@ authRoutes.post('/refresh', requireAuth(), async (c) => {
     }
     
     // Generate new token
-    const token = await AuthManager.generateToken(user.userId, user.email, user.role)
+    const token = await AuthManager.generateToken(user.userId, user.email, user.role, c.env.JWT_SECRET)
     
     // Set new cookie
     setCookie(c, 'auth_token', token, {
@@ -474,7 +474,7 @@ authRoutes.post('/register/form', async (c) => {
     ).run()
 
     // Generate JWT token
-    const token = await AuthManager.generateToken(userId, normalizedEmail, role)
+    const token = await AuthManager.generateToken(userId, normalizedEmail, role, c.env.JWT_SECRET)
 
     // Set HTTP-only cookie
     setCookie(c, 'auth_token', token, {
@@ -557,8 +557,8 @@ authRoutes.post('/login/form', async (c) => {
     }
     
     // Generate JWT token
-    const token = await AuthManager.generateToken(user.id, user.email, user.role)
-    
+    const token = await AuthManager.generateToken(user.id, user.email, user.role, c.env.JWT_SECRET)
+
     // Set HTTP-only cookie
     setCookie(c, 'auth_token', token, {
       httpOnly: true,
@@ -928,7 +928,7 @@ authRoutes.post('/accept-invitation', async (c) => {
     ).run()
 
     // Generate JWT token for auto-login
-    const authToken = await AuthManager.generateToken(invitedUser.id, invitedUser.email, invitedUser.role)
+    const authToken = await AuthManager.generateToken(invitedUser.id, invitedUser.email, invitedUser.role, c.env.JWT_SECRET)
     
     // Set HTTP-only cookie
     setCookie(c, 'auth_token', authToken, {


### PR DESCRIPTION
## Summary
Cherry-picked from #660 by @mmcintosh

Moves hardcoded JWT secret to an environment variable for proper secret management.

---
## Attribution
- Original PR: #660
- Original Author: @mmcintosh

Closes #660

🤖 Generated with [Claude Code](https://claude.com/claude-code)