### PR TITLE
security: validate sort order parameter to prevent SQL injection

### DIFF
--- a/packages/core/src/__tests__/utils/query-filter.test.ts
+++ b/packages/core/src/__tests__/utils/query-filter.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest'
-import { QueryFilterBuilder, buildQuery, type QueryFilter } from '../../utils/query-filter'
+import { describe, it, expect, vi } from 'vitest'
+import { QueryFilterBuilder, buildQuery, validateSortOrder, type QueryFilter } from '../../utils/query-filter'
 
 describe('QueryFilterBuilder', () => {
   it('should build basic SELECT query', () => {
@@ -898,5 +898,156 @@ describe('QueryFilterBuilder - Field Sanitization', () => {
     const result = builder.build('posts', filter)
 
     expect(result.sql).toBe('SELECT * FROM posts ORDER BY createdat DESC')
+  })
+})
+
+describe('Security: Sort order SQL injection prevention', () => {
+  describe('validateSortOrder', () => {
+    it('should accept "asc"', () => {
+      expect(validateSortOrder('asc')).toBe('asc')
+    })
+
+    it('should accept "desc"', () => {
+      expect(validateSortOrder('desc')).toBe('desc')
+    })
+
+    it('should accept "ASC" (case insensitive)', () => {
+      expect(validateSortOrder('ASC')).toBe('asc')
+    })
+
+    it('should accept "DESC" (case insensitive)', () => {
+      expect(validateSortOrder('DESC')).toBe('desc')
+    })
+
+    it('should accept "Desc" (mixed case)', () => {
+      expect(validateSortOrder('Desc')).toBe('desc')
+    })
+
+    it('should default to "asc" for SQL injection payload', () => {
+      expect(validateSortOrder('desc; DROP TABLE users; --')).toBe('asc')
+    })
+
+    it('should default to "asc" for UNION injection', () => {
+      expect(validateSortOrder('desc UNION SELECT * FROM users--')).toBe('asc')
+    })
+
+    it('should default to "asc" for empty string', () => {
+      expect(validateSortOrder('')).toBe('asc')
+    })
+
+    it('should default to "asc" for non-string values', () => {
+      expect(validateSortOrder(123)).toBe('asc')
+      expect(validateSortOrder(null)).toBe('asc')
+      expect(validateSortOrder(undefined)).toBe('asc')
+      expect(validateSortOrder({})).toBe('asc')
+      expect(validateSortOrder([])).toBe('asc')
+    })
+
+    it('should handle whitespace-padded values', () => {
+      expect(validateSortOrder(' asc ')).toBe('asc')
+      expect(validateSortOrder(' desc ')).toBe('desc')
+    })
+  })
+
+  describe('QueryFilterBuilder.build - sort order sanitization', () => {
+    it('should sanitize malicious sort order in SQL output', () => {
+      const builder = new QueryFilterBuilder()
+      const filter: QueryFilter = {
+        sort: [
+          { field: 'created_at', order: 'desc; DROP TABLE users; --' as any }
+        ]
+      }
+
+      const result = builder.build('content', filter)
+
+      expect(result.sql).toBe('SELECT * FROM content ORDER BY created_at ASC')
+      expect(result.sql).not.toContain('DROP')
+      expect(result.sql).not.toContain(';')
+    })
+
+    it('should sanitize UNION injection in sort order', () => {
+      const builder = new QueryFilterBuilder()
+      const filter: QueryFilter = {
+        sort: [
+          { field: 'id', order: 'asc UNION SELECT password FROM users--' as any }
+        ]
+      }
+
+      const result = builder.build('content', filter)
+
+      expect(result.sql).toBe('SELECT * FROM content ORDER BY id ASC')
+      expect(result.sql).not.toContain('UNION')
+      expect(result.sql).not.toContain('password')
+    })
+
+    it('should allow valid ASC order', () => {
+      const builder = new QueryFilterBuilder()
+      const filter: QueryFilter = {
+        sort: [{ field: 'name', order: 'asc' }]
+      }
+
+      const result = builder.build('users', filter)
+
+      expect(result.sql).toBe('SELECT * FROM users ORDER BY name ASC')
+    })
+
+    it('should allow valid DESC order', () => {
+      const builder = new QueryFilterBuilder()
+      const filter: QueryFilter = {
+        sort: [{ field: 'name', order: 'desc' }]
+      }
+
+      const result = builder.build('users', filter)
+
+      expect(result.sql).toBe('SELECT * FROM users ORDER BY name DESC')
+    })
+  })
+
+  describe('QueryFilterBuilder.parseFromQuery - sort order sanitization', () => {
+    it('should sanitize malicious sort order during parsing', () => {
+      const query = {
+        sort: JSON.stringify([{ field: 'created_at', order: 'desc; DROP TABLE users;--' }])
+      }
+
+      const filter = QueryFilterBuilder.parseFromQuery(query)
+
+      expect(filter.sort).toEqual([{ field: 'created_at', order: 'asc' }])
+    })
+
+    it('should preserve valid sort order during parsing', () => {
+      const query = {
+        sort: JSON.stringify([{ field: 'id', order: 'desc' }])
+      }
+
+      const filter = QueryFilterBuilder.parseFromQuery(query)
+
+      expect(filter.sort).toEqual([{ field: 'id', order: 'desc' }])
+    })
+
+    it('should filter out sort entries without a field', () => {
+      const query = {
+        sort: JSON.stringify([
+          { field: 'id', order: 'asc' },
+          { order: 'desc' },
+          { field: '', order: 'asc' }
+        ])
+      }
+
+      const filter = QueryFilterBuilder.parseFromQuery(query)
+
+      // Entry without field is filtered, entry with empty string field is kept (has typeof string)
+      expect(filter.sort?.length).toBe(2)
+      expect(filter.sort?.[0]).toEqual({ field: 'id', order: 'asc' })
+    })
+
+    it('should ignore non-array sort values', () => {
+      const query = {
+        sort: JSON.stringify({ field: 'id', order: 'asc' })
+      }
+
+      const filter = QueryFilterBuilder.parseFromQuery(query)
+
+      expect(filter.sort).toBeUndefined()
+    })
   })
 })

--- a/packages/core/src/routes/api.ts
+++ b/packages/core/src/routes/api.ts
@@ -656,10 +656,6 @@ apiRoutes.get('/content', optionalAuth(), async (c) => {
         count: results.length,
         timestamp: new Date().toISOString(),
         filter: normalizedFilter,
-        query: {
-          sql: queryResult.sql,
-          params: queryResult.params
-        },
         cache: {
           hit: false,
           source: 'database'
@@ -804,10 +800,6 @@ apiRoutes.get('/collections/:collection/content', optionalAuth(), async (c) => {
         count: results.length,
         timestamp: new Date().toISOString(),
         filter: normalizedFilter,
-        query: {
-          sql: queryResult.sql,
-          params: queryResult.params
-        },
         cache: {
           hit: false,
           source: 'database'

--- a/packages/core/src/utils/query-filter.ts
+++ b/packages/core/src/utils/query-filter.ts
@@ -49,6 +49,20 @@ export interface QueryResult {
 }
 
 /**
+ * Validate sort order value - only 'asc' or 'desc' are allowed.
+ * Returns the validated lowercase value, defaulting to 'asc' for invalid input.
+ */
+export function validateSortOrder(order: any): 'asc' | 'desc' {
+  if (typeof order === 'string') {
+    const normalized = order.toLowerCase().trim()
+    if (normalized === 'asc' || normalized === 'desc') {
+      return normalized
+    }
+  }
+  return 'asc'
+}
+
+/**
  * Query Filter Builder
  * Converts filter objects into SQL WHERE clauses with parameterized queries
  */
@@ -76,7 +90,7 @@ export class QueryFilterBuilder {
     // Build ORDER BY clause
     if (filter.sort && filter.sort.length > 0) {
       const orderClauses = filter.sort
-        .map(s => `${this.sanitizeFieldName(s.field)} ${s.order.toUpperCase()}`)
+        .map(s => `${this.sanitizeFieldName(s.field)} ${this.sanitizeSortOrder(s.order)}`)
         .join(', ')
       sql += ` ORDER BY ${orderClauses}`
     }
@@ -359,6 +373,18 @@ export class QueryFilterBuilder {
   }
 
   /**
+   * Sanitize sort order to prevent SQL injection
+   * Only allows 'ASC' or 'DESC', defaults to 'ASC' for any other value
+   */
+  private sanitizeSortOrder(order: string): string {
+    const normalized = String(order).toUpperCase().trim()
+    if (normalized === 'ASC' || normalized === 'DESC') {
+      return normalized
+    }
+    return 'ASC'
+  }
+
+  /**
    * Parse filter from query string
    */
   static parseFromQuery(query: Record<string, any>): QueryFilter {
@@ -413,9 +439,18 @@ export class QueryFilterBuilder {
     // Parse sort
     if (query.sort) {
       try {
-        filter.sort = typeof query.sort === 'string'
+        const parsed = typeof query.sort === 'string'
           ? JSON.parse(query.sort)
           : query.sort
+        // Validate and sanitize sort entries
+        if (Array.isArray(parsed)) {
+          filter.sort = parsed
+            .filter((s: any) => s && typeof s.field === 'string')
+            .map((s: any) => ({
+              field: s.field,
+              order: validateSortOrder(s.order)
+            }))
+        }
       } catch (e) {
         console.error('Failed to parse sort clause:', e)
       }


### PR DESCRIPTION
## Summary
Fixes a critical SQL injection vulnerability in the public `/api/content` endpoint via the `sort` query parameter's `order` field.

**No authentication required to exploit.**

### Changes
- **`packages/core/src/utils/query-filter.ts`** — Added `validateSortOrder()` whitelist validation (ASC/DESC only) at both parse time and SQL build time (defense in depth). Invalid values default to ASC.
- **`packages/core/src/routes/api.ts`** — Removed `meta.query.sql` and `meta.query.params` from API responses to prevent SQL query leakage
- **`packages/core/src/__tests__/utils/query-filter.test.ts`** — 20 new security tests covering injection payloads, edge cases, and parse-time sanitization

### Testing
- All 76 query-filter tests pass
- Type-check clean

## Credit
Vulnerability reported by Zhengyu Wang

Fixes #709

🤖 Generated with [Claude Code](https://claude.com/claude-code)