### PR TITLE
fix: Update X/Twitter link to fix username

### DIFF
--- a/www/src/app/faq/page.mdx
+++ b/www/src/app/faq/page.mdx
@@ -646,7 +646,7 @@ Multiple support channels available:
 **Community:**
 - [GitHub Discussions](https://github.com/lane711/sonicjs/discussions)
 - [Discord Server](https://discord.gg/8bMy6bv3sZ)
-- [Twitter/X](https://twitter.com/sonicjs)
+- [Twitter/X](https://x.com/SonicJsHeadless)
 
 **Professional Support:**
 - Email: support@sonicjs.com


### PR DESCRIPTION
Cherry-picked from #651 by @nickgraynews. One-line fix for incorrect Twitter/X username link.

Closes #651
🤖 Generated with [Claude Code](https://claude.com/claude-code)