### PR TITLE
feat: add rich text editor integration for global variables & shortcodes plugins

### DIFF
--- a/packages/core/src/plugins/core-plugins/_shared/admin-template.ts
+++ b/packages/core/src/plugins/core-plugins/_shared/admin-template.ts
@@ -1,0 +1,68 @@
+/**
+ * Shared Admin Page Template
+ *
+ * Provides the HTML wrapper for plugin admin pages with:
+ * - Tailwind CSS (CDN) with dark mode
+ * - HTMX for AJAX operations
+ * - CSRF token auto-injection (matches core admin layout pattern)
+ * - Inter font
+ */
+
+export function wrapAdminPage(opts: {
+  title: string
+  body: string
+}): string {
+  return `<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${opts.title} - SonicJS</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = { darkMode: 'class' }</script>
+  <script src="https://unpkg.com/htmx.org@2.0.3"></script>
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap">
+  <style>body { font-family: 'Inter', system-ui, sans-serif; }</style>
+
+  <!-- CSRF: Auto-attach token to all HTMX and fetch requests (matches core admin pattern) -->
+  <script>
+    function getCsrfToken() {
+      var cookie = document.cookie.split('; ')
+        .find(function(row) { return row.startsWith('csrf_token='); });
+      return cookie ? cookie.substring(cookie.indexOf('=') + 1) : '';
+    }
+
+    // HTMX: attach CSRF token to all requests
+    document.addEventListener('htmx:configRequest', function(event) {
+      var token = getCsrfToken();
+      if (token) {
+        event.detail.headers['X-CSRF-Token'] = token;
+      }
+    });
+
+    // fetch(): attach CSRF token to mutating requests
+    (function() {
+      var originalFetch = window.fetch;
+      window.fetch = function(url, options) {
+        options = options || {};
+        var method = (options.method || 'GET').toUpperCase();
+        if (method !== 'GET' && method !== 'HEAD' && method !== 'OPTIONS') {
+          options.headers = options.headers || {};
+          if (options.headers instanceof Headers) {
+            if (!options.headers.has('X-CSRF-Token')) {
+              options.headers.set('X-CSRF-Token', getCsrfToken());
+            }
+          } else if (!Array.isArray(options.headers) && !options.headers['X-CSRF-Token']) {
+            options.headers['X-CSRF-Token'] = getCsrfToken();
+          }
+        }
+        return originalFetch.call(this, url, options);
+      };
+    })();
+  </script>
+</head>
+<body class="bg-zinc-50 dark:bg-zinc-950 text-zinc-900 dark:text-zinc-100 min-h-screen">
+  ${opts.body}
+</body>
+</html>`
+}

--- a/packages/core/src/plugins/core-plugins/_shared/index.ts
+++ b/packages/core/src/plugins/core-plugins/_shared/index.ts
@@ -1,0 +1,3 @@
+export { wrapAdminPage } from './admin-template'
+export { getSharedQuillStyles, getSharedQuillScript, getQuillEnhancerPollerScript } from './quill-shared'
+export { getSharedTinyMceStyles, getTinyMcePluginScript } from './tinymce-shared'

--- a/packages/core/src/plugins/core-plugins/_shared/quill-shared.ts
+++ b/packages/core/src/plugins/core-plugins/_shared/quill-shared.ts
@@ -1,0 +1,400 @@
+/**
+ * Shared Quill Enhancement Utilities
+ *
+ * Provides the common CSS, picker dropdown, Quill constructor proxy, and
+ * helper functions used by both the Global Variables and Shortcodes plugins
+ * for their Quill editor integrations.
+ *
+ * Each plugin calls getSharedQuillSetup() to get the shared <style> + <script>
+ * block. At runtime, a `window.__sonicQuillShared` flag ensures these are only
+ * initialized once even if both plugins inject their scripts.
+ */
+
+/**
+ * Returns the shared CSS for blot chips, picker dropdown, and toolbar buttons.
+ * Wrapped in a dedupe check so it's safe to include from both plugins.
+ */
+export function getSharedQuillStyles(): string {
+  return `
+    <style id="sonic-quill-shared-styles">
+      /* Variable chip styles */
+      .ql-variable-blot {
+        display: inline-flex;
+        align-items: center;
+        gap: 3px;
+        background: rgba(59, 130, 246, 0.15);
+        border: 1px solid rgba(59, 130, 246, 0.3);
+        border-radius: 4px;
+        padding: 1px 6px;
+        font-family: ui-monospace, monospace;
+        font-size: 0.85em;
+        color: #60a5fa;
+        cursor: default;
+        user-select: all;
+        vertical-align: baseline;
+        line-height: 1.4;
+      }
+      .ql-variable-blot::before { content: '{'; opacity: 0.5; }
+      .ql-variable-blot::after { content: '}'; opacity: 0.5; }
+
+      /* Shortcode chip styles */
+      .ql-shortcode-blot {
+        display: inline-flex;
+        align-items: center;
+        gap: 3px;
+        background: rgba(168, 85, 247, 0.15);
+        border: 1px solid rgba(168, 85, 247, 0.3);
+        border-radius: 4px;
+        padding: 1px 6px;
+        font-family: ui-monospace, monospace;
+        font-size: 0.85em;
+        color: #c084fc;
+        cursor: default;
+        user-select: all;
+        vertical-align: baseline;
+        line-height: 1.4;
+      }
+      .ql-shortcode-blot::before { content: '[['; opacity: 0.5; }
+      .ql-shortcode-blot::after { content: ']]'; opacity: 0.5; }
+
+      /* Picker dropdown styles */
+      .sonic-picker-dropdown {
+        position: fixed;
+        z-index: 10000;
+        background: #18181b;
+        border: 1px solid #3f3f46;
+        border-radius: 8px;
+        box-shadow: 0 20px 25px -5px rgba(0,0,0,0.5);
+        min-width: 280px;
+        max-height: 360px;
+        overflow: hidden;
+        display: flex;
+        flex-direction: column;
+      }
+      .sonic-picker-dropdown .picker-header {
+        padding: 10px 12px;
+        border-bottom: 1px solid #27272a;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .sonic-picker-dropdown .picker-header input {
+        flex: 1;
+        background: #09090b;
+        border: 1px solid #3f3f46;
+        border-radius: 6px;
+        padding: 6px 10px;
+        font-size: 13px;
+        color: #e4e4e7;
+        outline: none;
+      }
+      .sonic-picker-dropdown .picker-header input:focus { border-color: #3b82f6; }
+      .sonic-picker-dropdown .picker-body {
+        overflow-y: auto;
+        max-height: 280px;
+        padding: 4px;
+      }
+      .sonic-picker-dropdown .picker-category {
+        padding: 6px 10px 2px;
+        font-size: 10px;
+        font-weight: 600;
+        text-transform: uppercase;
+        letter-spacing: 0.05em;
+        color: #71717a;
+      }
+      .sonic-picker-dropdown .picker-item {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 7px 10px;
+        border-radius: 6px;
+        cursor: pointer;
+        transition: background 0.1s;
+      }
+      .sonic-picker-dropdown .picker-item:hover { background: #27272a; }
+      .sonic-picker-dropdown .picker-item .item-key {
+        font-family: ui-monospace, monospace;
+        font-size: 13px;
+        font-weight: 500;
+      }
+      .sonic-picker-dropdown .picker-item .item-value {
+        font-size: 12px;
+        color: #71717a;
+        max-width: 140px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+      .sonic-picker-dropdown .picker-empty {
+        padding: 20px;
+        text-align: center;
+        color: #52525b;
+        font-size: 13px;
+      }
+
+      /* Toolbar button styles */
+      .ql-toolbar .ql-insertVariable,
+      .ql-toolbar .ql-insertShortcode {
+        width: auto !important;
+        padding: 3px 8px !important;
+        font-size: 12px !important;
+        font-weight: 500 !important;
+      }
+    </style>`;
+}
+
+/**
+ * Returns the shared JavaScript that sets up:
+ * - Quill constructor Proxy (injects custom formats into the whitelist)
+ * - Picker dropdown component (showPicker, closePicker)
+ * - insertBlot helper
+ * - enhanceQuillEditors polling framework
+ *
+ * Idempotent: checks window.__sonicQuillShared before running.
+ * Each plugin adds its own blot registration + toolbar button AFTER this.
+ */
+export function getSharedQuillScript(): string {
+  return `
+    <script>
+    (function() {
+      // ─── Shared setup: only runs once even if both plugins inject ──────
+      if (window.__sonicQuillShared) return;
+
+      function waitForQuill(cb) {
+        if (typeof Quill !== 'undefined') return cb();
+        setTimeout(function() { waitForQuill(cb); }, 50);
+      }
+
+      waitForQuill(function() {
+        // ─── Patch Quill constructor to allow custom blots ─────────
+        var OrigQuill = Quill;
+        var handler = {
+          construct: function(target, args) {
+            if (args[1] && args[1].formats && Array.isArray(args[1].formats)) {
+              if (!args[1].formats.includes('variable')) args[1].formats.push('variable');
+              if (!args[1].formats.includes('shortcode')) args[1].formats.push('shortcode');
+            }
+            return Reflect.construct(target, args);
+          }
+        };
+        if (typeof Proxy !== 'undefined') {
+          window.Quill = new Proxy(OrigQuill, handler);
+          Object.keys(OrigQuill).forEach(function(key) {
+            if (!(key in window.Quill)) window.Quill[key] = OrigQuill[key];
+          });
+          window.Quill.prototype = OrigQuill.prototype;
+          window.Quill.import = OrigQuill.import.bind(OrigQuill);
+          window.Quill.register = OrigQuill.register.bind(OrigQuill);
+          window.Quill.find = OrigQuill.find.bind(OrigQuill);
+          window.Quill.sources = OrigQuill.sources;
+        }
+
+        // ─── Picker Dropdown Component ─────────────────────────────
+        var activePicker = null;
+
+        function closePicker() {
+          if (activePicker) { activePicker.remove(); activePicker = null; }
+          document.removeEventListener('click', onDocClick);
+        }
+
+        function onDocClick(e) {
+          if (activePicker && !activePicker.contains(e.target)) closePicker();
+        }
+
+        function showPicker(opts) {
+          closePicker();
+          var dropdown = document.createElement('div');
+          dropdown.className = 'sonic-picker-dropdown';
+          var rect = opts.button.getBoundingClientRect();
+          dropdown.style.top = (rect.bottom + 4) + 'px';
+          dropdown.style.left = rect.left + 'px';
+
+          var header = document.createElement('div');
+          header.className = 'picker-header';
+          header.innerHTML = '<span style="font-size:14px">' + opts.icon + '</span>';
+          var searchInput = document.createElement('input');
+          searchInput.placeholder = 'Search ' + opts.label + '...';
+          searchInput.type = 'text';
+          header.appendChild(searchInput);
+          dropdown.appendChild(header);
+
+          var body = document.createElement('div');
+          body.className = 'picker-body';
+          dropdown.appendChild(body);
+
+          document.body.appendChild(dropdown);
+          activePicker = dropdown;
+          searchInput.focus();
+
+          var allItems = [];
+          fetch(opts.apiUrl)
+            .then(function(r) { return r.json(); })
+            .then(function(json) {
+              allItems = (json.data || []).filter(function(item) {
+                return opts.filterActive ? item.is_active : true;
+              });
+              renderItems(allItems);
+            })
+            .catch(function() {
+              body.innerHTML = '<div class="picker-empty">Failed to load</div>';
+            });
+
+          function renderItems(items) {
+            body.innerHTML = '';
+            if (items.length === 0) {
+              body.innerHTML = '<div class="picker-empty">No items found</div>';
+              return;
+            }
+            var groups = {};
+            items.forEach(function(item) {
+              var cat = item.category || 'general';
+              if (!groups[cat]) groups[cat] = [];
+              groups[cat].push(item);
+            });
+            Object.keys(groups).sort().forEach(function(cat) {
+              var catDiv = document.createElement('div');
+              catDiv.className = 'picker-category';
+              catDiv.textContent = cat;
+              body.appendChild(catDiv);
+              groups[cat].forEach(function(item) {
+                var itemDiv = document.createElement('div');
+                itemDiv.className = 'picker-item';
+                itemDiv.innerHTML = opts.renderItem(item);
+                itemDiv.addEventListener('click', function() {
+                  opts.onSelect(item);
+                  closePicker();
+                });
+                body.appendChild(itemDiv);
+              });
+            });
+          }
+
+          searchInput.addEventListener('input', function() {
+            var q = searchInput.value.toLowerCase();
+            var filtered = allItems.filter(function(item) {
+              return opts.getSearchText(item).toLowerCase().indexOf(q) !== -1;
+            });
+            renderItems(filtered);
+          });
+
+          setTimeout(function() { document.addEventListener('click', onDocClick); }, 10);
+        }
+
+        function insertBlot(q, position, type, value) {
+          q.focus();
+          q.insertEmbed(position, type, value, Quill.sources.USER);
+          q.setSelection(position + 1, 0, Quill.sources.SILENT);
+        }
+
+        // Expose shared utilities for plugin-specific scripts
+        window.__sonicQuillShared = {
+          showPicker: showPicker,
+          closePicker: closePicker,
+          insertBlot: insertBlot,
+          ready: true
+        };
+
+        console.log('[SonicJS] Shared Quill infrastructure initialized');
+      });
+    })();
+    </script>`;
+}
+
+/**
+ * Returns the polling script that enhances Quill editors with custom buttons.
+ * Each plugin registers its own enhancer function on window.__sonicQuillEnhancers[],
+ * and this shared poller runs them all.
+ *
+ * Idempotent: only one poller runs.
+ */
+export function getQuillEnhancerPollerScript(): string {
+  return `
+    <script>
+    (function() {
+      if (window.__sonicQuillPollerStarted) return;
+      window.__sonicQuillPollerStarted = true;
+      window.__sonicQuillEnhancers = window.__sonicQuillEnhancers || [];
+
+      function runEnhancers() {
+        var enhanced = 0;
+        document.querySelectorAll('.quill-editor-container').forEach(function(container) {
+          var editorDiv = container.querySelector('.quill-editor');
+          if (!editorDiv || !editorDiv.quillInstance) return;
+          if (container.dataset.sonicEnhanced === 'true') return;
+
+          var quill = editorDiv.quillInstance;
+          var toolbar = container.querySelector('.ql-toolbar');
+          if (!toolbar) return;
+
+          // Run all registered enhancers
+          window.__sonicQuillEnhancers.forEach(function(fn) {
+            try { fn(container, quill, toolbar); } catch(e) { console.error('[SonicJS] Enhancer error:', e); }
+          });
+
+          // Shared: serialize blots back to token syntax on text-change
+          quill.on('text-change', function() {
+            var fieldId = container.getAttribute('data-field-id');
+            var hiddenInput = document.getElementById(fieldId);
+            if (!hiddenInput) return;
+            var html = quill.root.innerHTML;
+            html = html.replace(/<span[^>]*class="ql-variable-blot"[^>]*data-variable-key="([^"]*)"[^>]*>[^<]*<\/span>/g,
+              function(m, key) { return '{' + key + '}'; });
+            html = html.replace(/<span[^>]*class="ql-shortcode-blot"[^>]*data-shortcode-name="([^"]*)"[^>]*(?:data-shortcode-params="([^"]*)")?[^>]*>[^<]*<\/span>/g,
+              function(m, name, params) { return '[[' + name + (params ? ' ' + params : '') + ']]'; });
+            hiddenInput.value = html;
+          });
+
+          // Shared: convert existing {key} and [[name]] tokens to blots
+          var delta = quill.getContents();
+          var newOps = [];
+          var changed = false;
+          delta.ops.forEach(function(op) {
+            if (typeof op.insert !== 'string') { newOps.push(op); return; }
+            var text = op.insert;
+            var regex = /(\{([a-z0-9_]+)\})|(\[\[(\w+)([^\]]*?)\]\])/g;
+            var lastIndex = 0;
+            var m;
+            while ((m = regex.exec(text)) !== null) {
+              if (m.index > lastIndex) newOps.push({ insert: text.slice(lastIndex, m.index), attributes: op.attributes });
+              if (m[1]) { newOps.push({ insert: { variable: { key: m[2] } } }); changed = true; }
+              else if (m[3]) { newOps.push({ insert: { shortcode: { name: m[4], params: (m[5] || '').trim() } } }); changed = true; }
+              lastIndex = m.index + m[0].length;
+            }
+            if (lastIndex < text.length) newOps.push({ insert: text.slice(lastIndex), attributes: op.attributes });
+            else if (lastIndex === 0) newOps.push(op);
+          });
+          if (changed) quill.setContents({ ops: newOps }, Quill.sources.SILENT);
+
+          container.dataset.sonicEnhanced = 'true';
+          enhanced++;
+        });
+        return enhanced;
+      }
+
+      // Poll until Quill instances appear
+      var attempts = 0;
+      function pollAndEnhance() {
+        attempts++;
+        // Wait for shared infra
+        if (!window.__sonicQuillShared || !window.__sonicQuillShared.ready) {
+          if (attempts < 60) setTimeout(pollAndEnhance, 200);
+          return;
+        }
+        var count = runEnhancers();
+        if (count > 0) {
+          console.log('[SonicJS] Enhanced ' + count + ' Quill editor(s)');
+        } else if (attempts < 30) {
+          setTimeout(pollAndEnhance, 200);
+        }
+      }
+      pollAndEnhance();
+
+      // Re-enhance after HTMX swaps
+      if (typeof htmx !== 'undefined') {
+        document.body.addEventListener('htmx:afterSwap', function() {
+          setTimeout(runEnhancers, 500);
+        });
+      }
+    })();
+    </script>`;
+}

--- a/packages/core/src/plugins/core-plugins/_shared/tinymce-shared.ts
+++ b/packages/core/src/plugins/core-plugins/_shared/tinymce-shared.ts
@@ -1,0 +1,204 @@
+/**
+ * TinyMCE Integration — PluginManager Approach
+ *
+ * Each plugin registers via `tinymce.PluginManager.add()` which is the official
+ * TinyMCE way to add buttons. The plugin is registered BEFORE `tinymce.init()`
+ * is called, and TinyMCE invokes it during initialization.
+ *
+ * The server-side HTML replacement in index.ts already:
+ * 1. Adds button names (sonicInsertVar, sonicInsertSC) to the toolbar config string
+ * 2. Injects the script tags BEFORE the initializeTinyMCE call
+ *
+ * So by the time tinymce.init() runs, PluginManager already knows our plugins,
+ * the toolbar string already references our button names, and the plugins array
+ * includes our plugin names. All three are handled by server-side HTML replacement.
+ *
+ * Each plugin also registers chip CSS + token-to-chip conversion via SetContent/GetContent.
+ */
+
+/** Picker dropdown CSS (shared, safe to duplicate) */
+export function getSharedTinyMceStyles(): string {
+  return `<style id="sonic-tinymce-styles">
+    .sonic-picker-dropdown{position:fixed;z-index:10000;background:#18181b;border:1px solid #3f3f46;border-radius:8px;box-shadow:0 20px 25px -5px rgba(0,0,0,.5);min-width:280px;max-height:360px;overflow:hidden;display:flex;flex-direction:column}
+    .sonic-picker-dropdown .picker-header{padding:10px 12px;border-bottom:1px solid #27272a;display:flex;align-items:center;gap:8px}
+    .sonic-picker-dropdown .picker-header input{flex:1;background:#09090b;border:1px solid #3f3f46;border-radius:6px;padding:6px 10px;font-size:13px;color:#e4e4e7;outline:none}
+    .sonic-picker-dropdown .picker-header input:focus{border-color:#3b82f6}
+    .sonic-picker-dropdown .picker-body{overflow-y:auto;max-height:280px;padding:4px}
+    .sonic-picker-dropdown .picker-category{padding:6px 10px 2px;font-size:10px;font-weight:600;text-transform:uppercase;letter-spacing:.05em;color:#71717a}
+    .sonic-picker-dropdown .picker-item{display:flex;align-items:center;justify-content:space-between;padding:7px 10px;border-radius:6px;cursor:pointer;transition:background .1s}
+    .sonic-picker-dropdown .picker-item:hover{background:#27272a}
+    .sonic-picker-dropdown .picker-item .item-key{font-family:ui-monospace,monospace;font-size:13px;font-weight:500}
+    .sonic-picker-dropdown .picker-item .item-value{font-size:12px;color:#71717a;max-width:140px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+    .sonic-picker-dropdown .picker-empty{padding:20px;text-align:center;color:#52525b;font-size:13px}
+  </style>`;
+}
+
+/**
+ * Returns a SELF-CONTAINED script that:
+ * - Sets up the picker dropdown (idempotent)
+ * - Registers a TinyMCE plugin via PluginManager.add() (the official way)
+ * - The plugin registers the toolbar button + chip CSS + token↔chip conversion
+ *
+ * Server-side (index.ts) handles adding button names to the toolbar string
+ * and plugin names to the plugins array. This script just needs to register
+ * the plugin in PluginManager before tinymce.init() is called.
+ */
+export function getTinyMcePluginScript(opts: {
+  buttonName: string
+  buttonText: string
+  buttonTooltip: string
+  pickerIcon: string
+  pickerLabel: string
+  pickerApiUrl: string
+  renderItemJs: string
+  getSearchTextJs: string
+  onSelectJs: string
+}): string {
+  const chipCSS = '.sonic-var-chip{display:inline;background:rgba(59,130,246,.15);border:1px solid rgba(59,130,246,.3);border-radius:4px;padding:1px 6px;font-family:ui-monospace,monospace;font-size:.85em;color:#60a5fa;cursor:default}.sonic-var-chip::before{content:\"{\";opacity:.5}.sonic-var-chip::after{content:\"}\";opacity:.5}.sonic-sc-chip{display:inline;background:rgba(168,85,247,.15);border:1px solid rgba(168,85,247,.3);border-radius:4px;padding:1px 6px;font-family:ui-monospace,monospace;font-size:.85em;color:#c084fc;cursor:default}.sonic-sc-chip::before{content:\"[[\";opacity:.5}.sonic-sc-chip::after{content:\"]]\";opacity:.5}';
+
+  // Each button gets its own TinyMCE plugin name (e.g., "sonicInsertVar" -> "sonicInsertVar")
+  // The plugin name matches the button name for simplicity.
+  const pluginName = opts.buttonName;
+
+  return `
+  <script>
+  (function() {
+    // ═══ 1. Picker dropdown (idempotent) ═══
+    if (!window.__sonicPicker) {
+      var ap = null;
+      function cp() { if (ap) { ap.remove(); ap = null; } document.removeEventListener('click', odc); }
+      function odc(e) { if (ap && !ap.contains(e.target)) cp(); }
+      window.__sonicPicker = function(opts) {
+        cp();
+        var dd = document.createElement('div'); dd.className = 'sonic-picker-dropdown';
+        var tb = document.querySelector('.tox-toolbar__primary');
+        if (tb) { var r = tb.getBoundingClientRect(); dd.style.top = (r.bottom+4)+'px'; dd.style.right = '20px'; }
+        else { dd.style.top = '60px'; dd.style.right = '20px'; }
+        var hd = document.createElement('div'); hd.className = 'picker-header';
+        hd.innerHTML = '<span style="font-size:14px">'+opts.icon+'</span>';
+        var si = document.createElement('input'); si.placeholder = 'Search '+opts.label+'...'; si.type = 'text';
+        hd.appendChild(si); dd.appendChild(hd);
+        var bd = document.createElement('div'); bd.className = 'picker-body'; dd.appendChild(bd);
+        document.body.appendChild(dd); ap = dd; si.focus();
+        var all = [];
+        fetch(opts.apiUrl).then(function(r){return r.json()}).then(function(j){
+          all = j.data || []; ri(all);
+        }).catch(function(){bd.innerHTML='<div class="picker-empty">Failed to load</div>'});
+        function ri(items) {
+          bd.innerHTML = '';
+          if (!items.length) { bd.innerHTML = '<div class="picker-empty">No items found</div>'; return; }
+          var g = {};
+          items.forEach(function(i){ var c=i.category||'general'; if(!g[c])g[c]=[]; g[c].push(i); });
+          Object.keys(g).sort().forEach(function(c){
+            var cd=document.createElement('div');cd.className='picker-category';cd.textContent=c;bd.appendChild(cd);
+            g[c].forEach(function(i){
+              var id=document.createElement('div');id.className='picker-item';
+              id.innerHTML=opts.renderItem(i);
+              id.addEventListener('click',function(){opts.onSelect(i);cp()});
+              bd.appendChild(id);
+            });
+          });
+        }
+        si.addEventListener('input',function(){
+          var q=si.value.toLowerCase();
+          ri(all.filter(function(i){return opts.getSearchText(i).toLowerCase().indexOf(q)!==-1}));
+        });
+        setTimeout(function(){document.addEventListener('click',odc)},10);
+      };
+    }
+
+    // ═══ 2. Track registered plugin names (for init wrapper) ═══
+    window.__sonicTmcePlugins = window.__sonicTmcePlugins || [];
+    // Keep these for diagnostics (the test checks them)
+    window.__sonicTmceButtons = window.__sonicTmceButtons || [];
+    window.__sonicTmceSetups = window.__sonicTmceSetups || [];
+
+    // ═══ 3. Register TinyMCE plugin via PluginManager (the OFFICIAL way) ═══
+    // This function waits for tinymce to be defined, then registers the plugin.
+    // PluginManager.add() MUST happen before tinymce.init() — the server-side
+    // injection places this script before the initializeTinyMCE call, so we
+    // just need to wait for the CDN to load tinymce.
+    function registerSonicPlugin() {
+      if (typeof tinymce === 'undefined' || !tinymce.PluginManager) return false;
+      if (tinymce.PluginManager.get('${pluginName}')) return true; // Already registered
+
+      tinymce.PluginManager.add('${pluginName}', function(editor) {
+        // Register the toolbar button
+        editor.ui.registry.addButton('${opts.buttonName}', {
+          text: '${opts.buttonText}',
+          tooltip: '${opts.buttonTooltip}',
+          onAction: function() {
+            window.__sonicPicker({
+              icon: '${opts.pickerIcon}',
+              label: '${opts.pickerLabel}',
+              apiUrl: '${opts.pickerApiUrl}',
+              renderItem: ${opts.renderItemJs},
+              getSearchText: ${opts.getSearchTextJs},
+              onSelect: function(item) { (${opts.onSelectJs})(editor, item); }
+            });
+          }
+        });
+
+        // Inject chip CSS into editor iframe
+        editor.on('init', function() {
+          var doc = editor.getDoc();
+          if (doc && !doc.getElementById('sonic-chip-css')) {
+            var style = doc.createElement('style');
+            style.id = 'sonic-chip-css';
+            style.textContent = '${chipCSS}';
+            doc.head.appendChild(style);
+          }
+        });
+
+        // Token→chip on content load
+        editor.on('SetContent', function() {
+          var b = editor.getBody(); if (!b) return;
+          var h = b.innerHTML, changed = false;
+          var r = h.replace(/\\{([a-z0-9_]+)\\}/g, function(m,k) {
+            changed = true;
+            return '<span class="sonic-var-chip" contenteditable="false" data-var-key="'+k+'">'+k+'</span>';
+          });
+          r = r.replace(/\\[\\[(\\w+)([^\\]]*?)\\]\\]/g, function(m,n,p) {
+            changed = true;
+            var pa = p.trim() ? ' data-sc-params="'+p.trim().replace(/"/g,'&amp;quot;')+'"' : '';
+            return '<span class="sonic-sc-chip" contenteditable="false" data-sc-name="'+n+'"'+pa+'>'+n+(p.trim()?' '+p.trim():'')+'</span>';
+          });
+          if (changed) editor.undoManager.ignore(function(){ b.innerHTML = r; });
+        });
+
+        // Chip→token on save
+        editor.on('GetContent', function(e) {
+          if (e.format !== 'html') return;
+          e.content = e.content.replace(/<span[^>]*class="[^"]*sonic-var-chip[^"]*"[^>]*data-var-key="([^"]*)"[^>]*>[^<]*<\\/span>/g,
+            function(m,k){ return '{'+k+'}'; });
+          e.content = e.content.replace(/<span[^>]*class="[^"]*sonic-sc-chip[^"]*"[^>]*data-sc-name="([^"]*)"[^>]*(?:data-sc-params="([^"]*)")?[^>]*>[^<]*<\\/span>/g,
+            function(m,n,p){ return '[['+n+(p?' '+p:'')+']]'; });
+        });
+
+        console.log('[SonicJS] TinyMCE plugin "${pluginName}" registered via PluginManager');
+      });
+
+      window.__sonicTmcePlugins.push('${pluginName}');
+      window.__sonicTmceButtons.push('${opts.buttonName}');
+      console.log('[SonicJS] PluginManager.add("${pluginName}") — done');
+      return true;
+    }
+
+    // Try immediately (tinymce CDN may already be loaded)
+    if (!registerSonicPlugin()) {
+      // Poll until tinymce is available (CDN loads async)
+      // The plugin MUST be registered before tinymce.init() is called.
+      // Server-side injection in index.ts adds our plugin name to the plugins array,
+      // so PluginManager just needs to have it registered by that time.
+      var attempts = 0;
+      var iv = setInterval(function() {
+        attempts++;
+        if (registerSonicPlugin() || attempts > 200) {
+          clearInterval(iv);
+          if (attempts > 200) console.warn('[SonicJS] Gave up waiting for tinymce to register ${pluginName}');
+        }
+      }, 25);
+    }
+  })();
+  </script>`;
+}

--- a/packages/core/src/plugins/core-plugins/global-variables-plugin/index.ts
+++ b/packages/core/src/plugins/core-plugins/global-variables-plugin/index.ts
@@ -1,341 +1,57 @@
 /**
- * Global Variables Plugin
+ * Global Variables Plugin — Enhanced
  *
- * Provides dynamic content variables (inline tokens) for rich text fields.
- * Variables are stored as key-value pairs and can be referenced in content
- * using {variable_key} syntax. They are resolved server-side on content read.
+ * Extends PR #743 (lane711/sonicjs) with:
+ * - Full CRUD admin page (add, inline edit, delete, toggle active/inactive)
+ * - Proper PluginBuilder lifecycle (install, activate, deactivate, uninstall)
+ * - Content read hook for {variable_key} server-side resolution
  *
- * Part 1: Global Variables Collection (CRUD API + admin UI)
- * Part 3: Server-Side Resolution (token replacement in content)
- * Part 2: Rich Text Inline Tokens (Quill UI) - planned for future PR
+ * Rich text editor integration: Quill blots (blue chips) + TinyMCE buttons via PluginManager
+ *
+ * @see https://github.com/lane711/sonicjs/issues/719
+ * @see https://github.com/lane711/sonicjs/pull/743
  */
 
 import { Hono } from 'hono'
-import { z } from 'zod'
-import type { Plugin } from '@sonicjs-cms/core'
-import { PluginBuilder } from '../../sdk/plugin-builder'
-import { resolveVariablesInObject } from './variable-resolver'
+import { PluginBuilder } from '../../../sdk/plugin-builder'
+import { wrapAdminPage } from '../_shared/admin-template'
+import {
+  resolveVariablesInObject,
+  invalidateVariablesCache,
+  getVariablesCached,
+  setVariablesCache,
+} from './variable-resolver'
+import {
+  getSharedQuillStyles,
+  getSharedQuillScript,
+  getQuillEnhancerPollerScript,
+} from '../_shared/quill-shared'
+import {
+  getSharedTinyMceStyles,
+  getTinyMcePluginScript,
+} from '../_shared/tinymce-shared'
 
-// ============================================================================
-// Schema & Migration
-// ============================================================================
+// ─── Migration SQL ───────────────────────────────────────────────────────────
 
-export const globalVariableSchema = z.object({
-  id: z.number().optional(),
-  key: z.string()
-    .min(1, 'Variable key is required')
-    .max(100, 'Key must be under 100 characters')
-    .regex(/^[a-z0-9_]+$/, 'Key must contain only lowercase letters, numbers, and underscores'),
-  value: z.string().max(10000, 'Value must be under 10,000 characters'),
-  description: z.string().max(500, 'Description must be under 500 characters').optional(),
-  category: z.string().max(50, 'Category must be under 50 characters').optional(),
-  isActive: z.boolean().default(true),
-  createdAt: z.number().optional(),
-  updatedAt: z.number().optional(),
-})
-
-export type GlobalVariable = z.infer<typeof globalVariableSchema>
-
-const globalVariablesMigration = `
+const MIGRATION_SQL = `
 CREATE TABLE IF NOT EXISTS global_variables (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   key TEXT NOT NULL UNIQUE,
   value TEXT NOT NULL DEFAULT '',
   description TEXT,
-  category TEXT,
+  category TEXT DEFAULT 'general',
   is_active INTEGER NOT NULL DEFAULT 1,
   created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
   updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
 );
-
 CREATE UNIQUE INDEX IF NOT EXISTS idx_global_variables_key ON global_variables(key);
 CREATE INDEX IF NOT EXISTS idx_global_variables_category ON global_variables(category);
 CREATE INDEX IF NOT EXISTS idx_global_variables_active ON global_variables(is_active);
-
-CREATE TRIGGER IF NOT EXISTS global_variables_updated_at
-  AFTER UPDATE ON global_variables
-BEGIN
-  UPDATE global_variables SET updated_at = strftime('%s', 'now') WHERE id = NEW.id;
-END;
 `
 
-// ============================================================================
-// In-memory variable cache
-// ============================================================================
+// ─── Helpers ─────────────────────────────────────────────────────────────────
 
-let variableCache: Map<string, string> | null = null
-let cacheTimestamp = 0
-const CACHE_TTL_MS = 300_000 // 5 minutes
-
-async function getVariablesMap(db: any): Promise<Map<string, string>> {
-  const now = Date.now()
-  if (variableCache && (now - cacheTimestamp) < CACHE_TTL_MS) {
-    return variableCache
-  }
-
-  try {
-    const { results } = await db.prepare(
-      'SELECT key, value FROM global_variables WHERE is_active = 1'
-    ).all()
-
-    const map = new Map<string, string>()
-    for (const row of results || []) {
-      map.set((row as any).key, (row as any).value)
-    }
-
-    variableCache = map
-    cacheTimestamp = now
-    return map
-  } catch {
-    // Table may not exist yet; return empty map
-    return new Map()
-  }
-}
-
-function invalidateCache(): void {
-  variableCache = null
-  cacheTimestamp = 0
-}
-
-// ============================================================================
-// API Routes
-// ============================================================================
-
-const apiRoutes = new Hono()
-
-// GET /api/global-variables — List all variables
-apiRoutes.get('/', async (c: any) => {
-  try {
-    const db = c.env?.DB
-    if (!db) {
-      return c.json({ error: 'Database not available' }, 500)
-    }
-
-    const { category, active } = c.req.query()
-    let query = 'SELECT * FROM global_variables WHERE 1=1'
-    const params: any[] = []
-
-    if (category) {
-      query += ' AND category = ?'
-      params.push(category)
-    }
-
-    if (active !== undefined) {
-      query += ' AND is_active = ?'
-      params.push(active === 'true' ? 1 : 0)
-    }
-
-    query += ' ORDER BY category ASC, key ASC'
-
-    const { results } = await db.prepare(query).bind(...params).all()
-
-    return c.json({
-      success: true,
-      data: (results || []).map(formatVariable),
-    })
-  } catch (error) {
-    return c.json({ success: false, error: 'Failed to fetch global variables' }, 500)
-  }
-})
-
-// GET /api/global-variables/resolve — Get a flat key→value map (for frontends)
-apiRoutes.get('/resolve', async (c: any) => {
-  try {
-    const db = c.env?.DB
-    if (!db) {
-      return c.json({ error: 'Database not available' }, 500)
-    }
-
-    const map = await getVariablesMap(db)
-    return c.json({
-      success: true,
-      data: Object.fromEntries(map),
-    })
-  } catch (error) {
-    return c.json({ success: false, error: 'Failed to resolve variables' }, 500)
-  }
-})
-
-// GET /api/global-variables/:id — Get single variable
-apiRoutes.get('/:id', async (c: any) => {
-  try {
-    const db = c.env?.DB
-    if (!db) {
-      return c.json({ error: 'Database not available' }, 500)
-    }
-
-    const id = c.req.param('id')
-    const result = await db.prepare('SELECT * FROM global_variables WHERE id = ?').bind(id).first()
-
-    if (!result) {
-      return c.json({ error: 'Variable not found' }, 404)
-    }
-
-    return c.json({ success: true, data: formatVariable(result) })
-  } catch (error) {
-    return c.json({ success: false, error: 'Failed to fetch variable' }, 500)
-  }
-})
-
-// POST /api/global-variables — Create variable
-apiRoutes.post('/', async (c: any) => {
-  try {
-    const db = c.env?.DB
-    if (!db) {
-      return c.json({ error: 'Database not available' }, 500)
-    }
-
-    const body = await c.req.json()
-    const parsed = globalVariableSchema.safeParse(body)
-    if (!parsed.success) {
-      return c.json({ error: 'Validation failed', details: parsed.error.flatten() }, 400)
-    }
-
-    const { key, value, description, category, isActive } = parsed.data
-
-    // Check for duplicate key
-    const existing = await db.prepare('SELECT id FROM global_variables WHERE key = ?').bind(key).first()
-    if (existing) {
-      return c.json({ error: `Variable with key "${key}" already exists` }, 409)
-    }
-
-    await db.prepare(
-      'INSERT INTO global_variables (key, value, description, category, is_active) VALUES (?, ?, ?, ?, ?)'
-    ).bind(key, value, description || null, category || null, isActive ? 1 : 0).run()
-
-    invalidateCache()
-
-    const created = await db.prepare('SELECT * FROM global_variables WHERE key = ?').bind(key).first()
-    return c.json({ success: true, data: formatVariable(created) }, 201)
-  } catch (error) {
-    return c.json({ success: false, error: 'Failed to create variable' }, 500)
-  }
-})
-
-// PUT /api/global-variables/:id — Update variable
-apiRoutes.put('/:id', async (c: any) => {
-  try {
-    const db = c.env?.DB
-    if (!db) {
-      return c.json({ error: 'Database not available' }, 500)
-    }
-
-    const id = c.req.param('id')
-    const existing = await db.prepare('SELECT * FROM global_variables WHERE id = ?').bind(id).first()
-    if (!existing) {
-      return c.json({ error: 'Variable not found' }, 404)
-    }
-
-    const body = await c.req.json()
-    const updates: string[] = []
-    const params: any[] = []
-
-    if (body.key !== undefined) {
-      const keyValidation = z.string().min(1).max(100).regex(/^[a-z0-9_]+$/).safeParse(body.key)
-      if (!keyValidation.success) {
-        return c.json({ error: 'Invalid key format' }, 400)
-      }
-      // Check uniqueness if key changed
-      if (body.key !== (existing as any).key) {
-        const dup = await db.prepare('SELECT id FROM global_variables WHERE key = ? AND id != ?').bind(body.key, id).first()
-        if (dup) {
-          return c.json({ error: `Variable with key "${body.key}" already exists` }, 409)
-        }
-      }
-      updates.push('key = ?')
-      params.push(body.key)
-    }
-
-    if (body.value !== undefined) {
-      updates.push('value = ?')
-      params.push(body.value)
-    }
-
-    if (body.description !== undefined) {
-      updates.push('description = ?')
-      params.push(body.description)
-    }
-
-    if (body.category !== undefined) {
-      updates.push('category = ?')
-      params.push(body.category)
-    }
-
-    if (body.isActive !== undefined) {
-      updates.push('is_active = ?')
-      params.push(body.isActive ? 1 : 0)
-    }
-
-    if (updates.length === 0) {
-      return c.json({ error: 'No fields to update' }, 400)
-    }
-
-    params.push(id)
-    await db.prepare(`UPDATE global_variables SET ${updates.join(', ')} WHERE id = ?`).bind(...params).run()
-
-    invalidateCache()
-
-    const updated = await db.prepare('SELECT * FROM global_variables WHERE id = ?').bind(id).first()
-    return c.json({ success: true, data: formatVariable(updated) })
-  } catch (error) {
-    return c.json({ success: false, error: 'Failed to update variable' }, 500)
-  }
-})
-
-// DELETE /api/global-variables/:id — Delete variable
-apiRoutes.delete('/:id', async (c: any) => {
-  try {
-    const db = c.env?.DB
-    if (!db) {
-      return c.json({ error: 'Database not available' }, 500)
-    }
-
-    const id = c.req.param('id')
-    const existing = await db.prepare('SELECT id FROM global_variables WHERE id = ?').bind(id).first()
-    if (!existing) {
-      return c.json({ error: 'Variable not found' }, 404)
-    }
-
-    await db.prepare('DELETE FROM global_variables WHERE id = ?').bind(id).run()
-    invalidateCache()
-
-    return c.json({ success: true })
-  } catch (error) {
-    return c.json({ success: false, error: 'Failed to delete variable' }, 500)
-  }
-})
-
-// ============================================================================
-// Admin Routes
-// ============================================================================
-
-const adminRoutes = new Hono()
-
-adminRoutes.get('/', async (c: any) => {
-  const db = c.env?.DB
-  let variables: any[] = []
-
-  try {
-    if (db) {
-      const { results } = await db.prepare(
-        'SELECT * FROM global_variables ORDER BY category ASC, key ASC'
-      ).all()
-      variables = (results || []).map(formatVariable)
-    }
-  } catch {
-    // Table may not exist yet
-  }
-
-  const categories = [...new Set(variables.map((v: any) => v.category).filter(Boolean))]
-
-  return c.html(renderAdminPage(variables, categories))
-})
-
-// ============================================================================
-// Helpers
-// ============================================================================
-
-function formatVariable(row: any): any {
+function formatVariable(row: any) {
   if (!row) return null
   return {
     id: row.id,
@@ -349,134 +65,641 @@ function formatVariable(row: any): any {
   }
 }
 
-function renderAdminPage(variables: any[], categories: string[]): string {
-  const rows = variables.map((v: any) => `
-    <tr class="border-b border-zinc-200 dark:border-zinc-700">
-      <td class="px-4 py-3 font-mono text-sm text-blue-600 dark:text-blue-400">{${v.key}}</td>
-      <td class="px-4 py-3 text-sm max-w-xs truncate">${escapeHtml(v.value)}</td>
-      <td class="px-4 py-3 text-sm text-zinc-500">${escapeHtml(v.description || '')}</td>
-      <td class="px-4 py-3 text-sm">${v.category ? `<span class="px-2 py-0.5 bg-zinc-100 dark:bg-zinc-800 rounded text-xs">${escapeHtml(v.category)}</span>` : ''}</td>
-      <td class="px-4 py-3 text-center">
-        <span class="inline-block w-2 h-2 rounded-full ${v.isActive ? 'bg-green-500' : 'bg-zinc-400'}"></span>
-      </td>
-    </tr>
+function esc(s: string): string {
+  return (s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}
+
+async function getVariablesMap(db: any): Promise<Map<string, string>> {
+  let variables = getVariablesCached()
+  if (variables) return variables
+  try {
+    const { results } = await db.prepare(
+      'SELECT key, value FROM global_variables WHERE is_active = 1'
+    ).all()
+    variables = new Map<string, string>()
+    for (const row of results || []) {
+      variables.set((row as any).key, (row as any).value)
+    }
+    setVariablesCache(variables)
+    return variables
+  } catch {
+    return new Map()
+  }
+}
+
+// ─── API Routes ──────────────────────────────────────────────────────────────
+
+const apiRoutes = new Hono()
+
+// Gate: all routes return 404 if this plugin is inactive
+apiRoutes.use('*', async (c: any, next: any) => {
+  try {
+    const db = c.env?.DB
+    if (db) {
+      const row = await db.prepare("SELECT status FROM plugins WHERE id = 'global-variables' AND status = 'active'").first()
+      if (!row) return c.json({ error: 'Plugin not active' }, 404)
+    }
+  } catch { /* allow if table doesn't exist yet */ }
+  await next()
+})
+
+apiRoutes.get('/', async (c: any) => {
+  try {
+    const db = c.env.DB
+    const category = c.req.query('category')
+    const active = c.req.query('active')
+
+    let query = 'SELECT * FROM global_variables WHERE 1=1'
+    const params: any[] = []
+    if (category) { query += ' AND category = ?'; params.push(category) }
+    if (active !== undefined) { query += ' AND is_active = ?'; params.push(active === 'true' ? 1 : 0) }
+    query += ' ORDER BY category ASC, key ASC'
+
+    const { results } = await db.prepare(query).bind(...params).all()
+    return c.json({ success: true, data: (results || []).map(formatVariable) })
+  } catch {
+    return c.json({ success: false, error: 'Failed to fetch global variables' }, 500)
+  }
+})
+
+apiRoutes.get('/resolve', async (c: any) => {
+  try {
+    const map = await getVariablesMap(c.env.DB)
+    return c.json({ success: true, data: Object.fromEntries(map) })
+  } catch {
+    return c.json({ success: false, error: 'Failed to resolve variables' }, 500)
+  }
+})
+
+apiRoutes.get('/:id', async (c: any) => {
+  try {
+    const result = await c.env.DB.prepare('SELECT * FROM global_variables WHERE id = ?').bind(c.req.param('id')).first()
+    if (!result) return c.json({ error: 'Variable not found' }, 404)
+    return c.json({ success: true, data: formatVariable(result) })
+  } catch {
+    return c.json({ success: false, error: 'Failed to fetch variable' }, 500)
+  }
+})
+
+apiRoutes.post('/', async (c: any) => {
+  try {
+    const db = c.env.DB
+    const { key, value, description, category, isActive } = await c.req.json()
+    if (!key || !/^[a-z0-9_]+$/.test(key)) {
+      return c.json({ error: 'Key must be lowercase alphanumeric with underscores' }, 400)
+    }
+    const existing = await db.prepare('SELECT id FROM global_variables WHERE key = ?').bind(key).first()
+    if (existing) return c.json({ error: `Variable with key "${key}" already exists` }, 409)
+
+    await db.prepare(
+      'INSERT INTO global_variables (key, value, description, category, is_active) VALUES (?, ?, ?, ?, ?)'
+    ).bind(key, value || '', description || '', category || 'general', isActive !== false ? 1 : 0).run()
+    invalidateVariablesCache()
+
+    const created = await db.prepare('SELECT * FROM global_variables WHERE key = ?').bind(key).first()
+    return c.json({ success: true, data: formatVariable(created) }, 201)
+  } catch {
+    return c.json({ success: false, error: 'Failed to create variable' }, 500)
+  }
+})
+
+apiRoutes.put('/:id', async (c: any) => {
+  try {
+    const db = c.env.DB
+    const id = c.req.param('id')
+    const existing = await db.prepare('SELECT * FROM global_variables WHERE id = ?').bind(id).first() as any
+    if (!existing) return c.json({ error: 'Variable not found' }, 404)
+
+    const body = await c.req.json()
+    const updates: string[] = []
+    const params: any[] = []
+
+    if (body.value !== undefined) { updates.push('value = ?'); params.push(body.value) }
+    if (body.description !== undefined) { updates.push('description = ?'); params.push(body.description) }
+    if (body.category !== undefined) { updates.push('category = ?'); params.push(body.category) }
+    if (body.isActive !== undefined) { updates.push('is_active = ?'); params.push(body.isActive ? 1 : 0) }
+    if (body.key !== undefined) {
+      if (!/^[a-z0-9_]+$/.test(body.key)) return c.json({ error: 'Invalid key format' }, 400)
+      if (body.key !== existing.key) {
+        const dup = await db.prepare('SELECT id FROM global_variables WHERE key = ? AND id != ?').bind(body.key, id).first()
+        if (dup) return c.json({ error: `Key "${body.key}" already exists` }, 409)
+      }
+      updates.push('key = ?'); params.push(body.key)
+    }
+
+    if (updates.length === 0) return c.json({ error: 'No fields to update' }, 400)
+    updates.push('updated_at = strftime(\'%s\', \'now\')')
+    params.push(id)
+    await db.prepare(`UPDATE global_variables SET ${updates.join(', ')} WHERE id = ?`).bind(...params).run()
+    invalidateVariablesCache()
+
+    const updated = await db.prepare('SELECT * FROM global_variables WHERE id = ?').bind(id).first()
+    return c.json({ success: true, data: formatVariable(updated) })
+  } catch {
+    return c.json({ success: false, error: 'Failed to update variable' }, 500)
+  }
+})
+
+apiRoutes.delete('/:id', async (c: any) => {
+  try {
+    const db = c.env.DB
+    const id = c.req.param('id')
+    const existing = await db.prepare('SELECT id FROM global_variables WHERE id = ?').bind(id).first()
+    if (!existing) return c.json({ error: 'Variable not found' }, 404)
+    await db.prepare('DELETE FROM global_variables WHERE id = ?').bind(id).run()
+    invalidateVariablesCache()
+    return c.json({ success: true })
+  } catch {
+    return c.json({ success: false, error: 'Failed to delete variable' }, 500)
+  }
+})
+
+// ─── Admin Page ──────────────────────────────────────────────────────────────
+
+const adminRoutes = new Hono()
+
+adminRoutes.use('*', async (c: any, next: any) => {
+  try {
+    const db = c.env?.DB
+    if (db) {
+      const row = await db.prepare("SELECT status FROM plugins WHERE id = 'global-variables' AND status = 'active'").first()
+      if (!row) return c.html('<html><body><h1>Plugin not active</h1><p>Enable the Global Variables plugin from <a href="/admin/plugins">Plugins</a>.</p></body></html>', 404)
+    }
+  } catch { /* allow */ }
+  await next()
+})
+
+adminRoutes.get('/', async (c: any) => {
+  const db = c.env.DB
+  let variables: any[] = []
+  try {
+    const { results } = await db.prepare('SELECT * FROM global_variables ORDER BY category ASC, key ASC').all()
+    variables = (results || []).map(formatVariable)
+  } catch { /* table may not exist yet */ }
+
+  // Fetch editor integration status
+  let editorActive = false
+  let activeEditorName = ''
+  let enableEditorIntegration = true
+  try {
+    const qeRow = await db.prepare("SELECT status FROM plugins WHERE (id = 'quill-editor' OR name = 'quill-editor') AND status = 'active'").first()
+    const tmRow = await db.prepare("SELECT status FROM plugins WHERE (id = 'tinymce-plugin' OR name = 'tinymce-plugin') AND status = 'active'").first()
+    if (qeRow) { editorActive = true; activeEditorName = 'Quill Editor' }
+    else if (tmRow) { editorActive = true; activeEditorName = 'TinyMCE' }
+    const gvRow = await db.prepare("SELECT settings FROM plugins WHERE id = 'global-variables'").first() as any
+    if (gvRow?.settings) {
+      const settings = typeof gvRow.settings === 'string' ? JSON.parse(gvRow.settings) : gvRow.settings
+      enableEditorIntegration = settings.enableEditorIntegration !== false
+    }
+  } catch { /* ignore */ }
+
+  return c.html(renderAdminPage(variables, { editorActive, activeEditorName, enableEditorIntegration }))
+})
+
+// HTMX: inline update value
+adminRoutes.put('/:id', async (c: any) => {
+  const db = c.env.DB
+  const id = c.req.param('id')
+  let body: any
+  try { body = await c.req.json() } catch { body = await c.req.parseBody() }
+  const value = body.value
+  if (value !== undefined) {
+    await db.prepare('UPDATE global_variables SET value = ?, updated_at = strftime(\'%s\', \'now\') WHERE id = ?').bind(value, id).run()
+    invalidateVariablesCache()
+  }
+  return c.html('<span class="text-green-400 text-xs">Saved</span>')
+})
+
+// HTMX: toggle active
+adminRoutes.post('/:id/toggle', async (c: any) => {
+  const db = c.env.DB
+  const id = c.req.param('id')
+  await db.prepare('UPDATE global_variables SET is_active = CASE WHEN is_active = 1 THEN 0 ELSE 1 END, updated_at = strftime(\'%s\', \'now\') WHERE id = ?').bind(id).run()
+  invalidateVariablesCache()
+  c.header('HX-Redirect', '/admin/global-variables')
+  return c.body(null, 204)
+})
+
+// HTMX: create variable
+adminRoutes.post('/', async (c: any) => {
+  const db = c.env.DB
+  const form = await c.req.parseBody()
+  const key = (form.key as string || '').trim()
+  const value = (form.value as string || '').trim()
+  const category = (form.category as string || 'general').trim()
+  const description = (form.description as string || '').trim()
+
+  if (!key || !/^[a-z0-9_]+$/.test(key)) {
+    return c.html('<div class="bg-red-500/10 border border-red-500/30 text-red-400 text-sm rounded-lg px-4 py-2 mb-4">Key must be lowercase alphanumeric with underscores only</div>')
+  }
+
+  const existing = await db.prepare('SELECT id FROM global_variables WHERE key = ?').bind(key).first()
+  if (existing) {
+    return c.html(`<div class="bg-red-500/10 border border-red-500/30 text-red-400 text-sm rounded-lg px-4 py-2 mb-4">Variable with key "${esc(key)}" already exists</div>`)
+  }
+
+  await db.prepare(
+    'INSERT INTO global_variables (key, value, description, category) VALUES (?, ?, ?, ?)'
+  ).bind(key, value, description, category).run()
+  invalidateVariablesCache()
+
+  c.header('HX-Redirect', '/admin/global-variables')
+  return c.body(null, 204)
+})
+
+// Toggle editor integration setting
+adminRoutes.post('/settings/editor-integration', async (c: any) => {
+  const db = c.env.DB
+  try {
+    const row = await db.prepare("SELECT settings FROM plugins WHERE id = 'global-variables'").first() as any
+    const settings = row?.settings ? (typeof row.settings === 'string' ? JSON.parse(row.settings) : row.settings) : {}
+    settings.enableEditorIntegration = !settings.enableEditorIntegration
+    await db.prepare("UPDATE plugins SET settings = ? WHERE id = 'global-variables'").bind(JSON.stringify(settings)).run()
+    return c.json({ success: true, enableEditorIntegration: settings.enableEditorIntegration })
+  } catch {
+    return c.json({ success: false, error: 'Failed to update setting' }, 500)
+  }
+})
+
+// HTMX: delete variable
+adminRoutes.delete('/:id', async (c: any) => {
+  const db = c.env.DB
+  await db.prepare('DELETE FROM global_variables WHERE id = ?').bind(c.req.param('id')).run()
+  invalidateVariablesCache()
+  return c.html('')
+})
+
+// ─── Admin Page Template ─────────────────────────────────────────────────────
+
+function renderAdminPage(variables: any[], editorStatus: { editorActive: boolean; activeEditorName: string; enableEditorIntegration: boolean } = { editorActive: false, activeEditorName: '', enableEditorIntegration: true }): string {
+  // Group by category
+  const groups = new Map<string, any[]>()
+  for (const v of variables) {
+    const cat = v.category || 'general'
+    if (!groups.has(cat)) groups.set(cat, [])
+    groups.get(cat)!.push(v)
+  }
+
+  const categoryHtml = Array.from(groups.entries()).map(([cat, vars]) => `
+    <div class="mb-6">
+      <h3 class="text-xs font-semibold text-zinc-500 uppercase tracking-wider mb-2 flex items-center gap-2">
+        <span class="w-1.5 h-1.5 rounded-full bg-blue-500"></span>
+        ${esc(cat)} <span class="text-zinc-600">(${vars.length})</span>
+      </h3>
+      <div class="bg-white dark:bg-zinc-900 rounded-lg border border-zinc-200 dark:border-zinc-800 overflow-hidden">
+        <table class="w-full">
+          <tbody>
+            ${vars.map(v => `
+              <tr class="border-b border-zinc-100 dark:border-zinc-800 last:border-0 group" id="var-${v.id}" data-original="${esc(v.value)}">
+                <td class="px-4 py-3 w-48">
+                  <code class="text-sm font-mono text-blue-600 dark:text-blue-400">{${esc(v.key)}}</code>
+                  ${v.description ? `<div class="text-xs text-zinc-500 mt-0.5 truncate max-w-[200px]">${esc(v.description)}</div>` : ''}
+                </td>
+                <td class="px-4 py-3">
+                  <div class="flex items-center gap-2">
+                    <input type="text" value="${esc(v.value)}" data-id="${v.id}"
+                           class="var-value-input flex-1 rounded-md border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800 px-3 py-1.5 text-sm text-zinc-900 dark:text-zinc-100 focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:bg-white dark:focus:bg-zinc-900"
+                           oninput="markDirty(this)" />
+                    <button onclick="saveVariable(${v.id}, this)" class="save-btn hidden rounded-md bg-blue-600 px-3 py-1 text-xs font-medium text-white hover:bg-blue-500 transition-colors">
+                      Save
+                    </button>
+                    <span class="save-status text-xs w-16"></span>
+                  </div>
+                </td>
+                <td class="px-3 py-3 w-20 text-center">
+                  <button onclick="toggleVariable(${v.id})"
+                          class="inline-flex items-center rounded-full px-2.5 py-1 text-xs font-medium transition-colors cursor-pointer
+                          ${v.isActive ? 'bg-green-500/10 text-green-600 dark:text-green-400 hover:bg-green-500/20' : 'bg-zinc-100 dark:bg-zinc-800 text-zinc-500 hover:bg-zinc-200 dark:hover:bg-zinc-700'}"
+                          title="Click to ${v.isActive ? 'deactivate' : 'activate'}">
+                    ${v.isActive ? 'Active' : 'Off'}
+                  </button>
+                </td>
+                <td class="px-3 py-3 w-10">
+                  <button onclick="deleteVariable(${v.id}, '{${esc(v.key)}}')"
+                          class="rounded p-1.5 text-zinc-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-500/10 opacity-0 group-hover:opacity-100 transition-all"
+                          title="Delete">
+                    <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
+                  </button>
+                </td>
+              </tr>
+            `).join('')}
+          </tbody>
+        </table>
+      </div>
+    </div>
   `).join('')
 
-  return `<!DOCTYPE html>
-<html lang="en" class="dark">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Global Variables - SonicJS</title>
-  <script src="https://cdn.tailwindcss.com"></script>
-  <script>tailwind.config = { darkMode: 'class' }</script>
-</head>
-<body class="bg-white dark:bg-zinc-950 text-zinc-950 dark:text-white min-h-screen">
-  <div class="p-8">
-    <div class="mb-8">
-      <h1 class="text-3xl font-bold mb-2">Global Variables</h1>
-      <p class="text-zinc-600 dark:text-zinc-400">
-        Manage dynamic content variables. Use <code class="text-sm bg-zinc-100 dark:bg-zinc-800 px-1.5 py-0.5 rounded">{variable_key}</code> syntax in rich text fields.
-      </p>
+  return wrapAdminPage({ title: 'Global Variables', body: `
+  <div class="max-w-4xl mx-auto px-6 py-8">
+    <!-- Header -->
+    <div class="flex items-center justify-between mb-6">
+      <div>
+        <div class="flex items-center gap-2 mb-1">
+          <a href="/admin/dashboard" class="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+          </a>
+          <h1 class="text-2xl font-bold">Global Variables</h1>
+        </div>
+        <p class="text-sm text-zinc-500">
+          Dynamic content tokens. Use <code class="text-blue-600 dark:text-blue-400 bg-blue-50 dark:bg-blue-500/10 px-1.5 py-0.5 rounded text-xs">{variable_key}</code> in rich text — resolved server-side on content read.
+        </p>
+      </div>
+      <div class="text-sm text-zinc-500">${variables.length} variable${variables.length !== 1 ? 's' : ''}</div>
     </div>
 
-    <div class="bg-white dark:bg-zinc-900 rounded-lg border border-zinc-200 dark:border-zinc-800 shadow-sm overflow-hidden">
-      <table class="w-full">
-        <thead>
-          <tr class="border-b border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800/50">
-            <th class="px-4 py-3 text-left text-xs font-medium text-zinc-500 uppercase">Token</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-zinc-500 uppercase">Value</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-zinc-500 uppercase">Description</th>
-            <th class="px-4 py-3 text-left text-xs font-medium text-zinc-500 uppercase">Category</th>
-            <th class="px-4 py-3 text-center text-xs font-medium text-zinc-500 uppercase">Active</th>
-          </tr>
-        </thead>
-        <tbody>
-          ${rows || '<tr><td colspan="5" class="px-4 py-8 text-center text-zinc-500">No variables defined yet. Use the API to create variables.</td></tr>'}
-        </tbody>
-      </table>
+    <!-- Variables list -->
+    <div id="variables-list">
+      ${categoryHtml || `
+        <div class="bg-white dark:bg-zinc-900 rounded-lg border border-zinc-200 dark:border-zinc-800 p-12 text-center">
+          <div class="text-4xl mb-3">🔤</div>
+          <h3 class="text-lg font-medium mb-1">No variables yet</h3>
+          <p class="text-sm text-zinc-500">Create your first variable below to get started.</p>
+        </div>
+      `}
     </div>
 
-    <div class="mt-6 bg-blue-50 dark:bg-blue-950 border border-blue-200 dark:border-blue-800 rounded-lg p-6">
-      <h3 class="font-semibold text-blue-900 dark:text-blue-100 mb-2">API Reference</h3>
-      <ul class="text-sm text-blue-800 dark:text-blue-200 space-y-1">
-        <li><code>GET /api/global-variables</code> &mdash; List all variables</li>
-        <li><code>GET /api/global-variables/resolve</code> &mdash; Get key&rarr;value map</li>
-        <li><code>POST /api/global-variables</code> &mdash; Create variable</li>
-        <li><code>PUT /api/global-variables/:id</code> &mdash; Update variable</li>
-        <li><code>DELETE /api/global-variables/:id</code> &mdash; Delete variable</li>
-      </ul>
+    <!-- Add new variable form -->
+    <div class="mt-6 bg-white dark:bg-zinc-900 rounded-lg border border-zinc-200 dark:border-zinc-800 p-5">
+      <h3 class="text-sm font-semibold mb-3">Add Variable</h3>
+      <form class="space-y-3">
+        <div class="grid grid-cols-12 gap-3">
+          <div class="col-span-3">
+            <label class="block text-xs text-zinc-500 mb-1">Key</label>
+            <input type="text" name="key" required pattern="[a-z0-9_]+" placeholder="variable_key"
+                   class="w-full rounded-md border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800 px-3 py-2 text-sm font-mono placeholder-zinc-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500" />
+          </div>
+          <div class="col-span-3">
+            <label class="block text-xs text-zinc-500 mb-1">Value</label>
+            <input type="text" name="value" required placeholder="Value"
+                   class="w-full rounded-md border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800 px-3 py-2 text-sm placeholder-zinc-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500" />
+          </div>
+          <div class="col-span-2">
+            <label class="block text-xs text-zinc-500 mb-1">Category</label>
+            <input type="text" name="category" placeholder="general" value="general"
+                   class="w-full rounded-md border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800 px-3 py-2 text-sm placeholder-zinc-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500" />
+          </div>
+          <div class="col-span-3">
+            <label class="block text-xs text-zinc-500 mb-1">Description</label>
+            <input type="text" name="description" placeholder="Optional"
+                   class="w-full rounded-md border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800 px-3 py-2 text-sm placeholder-zinc-400 focus:border-blue-500 focus:ring-1 focus:ring-blue-500" />
+          </div>
+          <div class="col-span-1 flex items-end">
+            <button type="submit" class="w-full rounded-md bg-zinc-900 dark:bg-white px-3 py-2 text-sm font-medium text-white dark:text-zinc-900 hover:bg-zinc-800 dark:hover:bg-zinc-100 transition-colors">
+              Add
+            </button>
+          </div>
+        </div>
+      </form>
     </div>
+
+    <!-- Rich Text Editor Integration -->
+    <div class="mt-6 bg-white dark:bg-zinc-900 rounded-lg border border-zinc-200 dark:border-zinc-800 p-5">
+      <div class="flex items-center justify-between">
+        <div>
+          <h3 class="text-sm font-semibold flex items-center gap-2">
+            Rich Text Editor Integration
+            ${editorStatus.editorActive && editorStatus.enableEditorIntegration
+              ? `<span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs bg-green-500/10 text-green-600 dark:text-green-400">Active — ${esc(editorStatus.activeEditorName)}</span>`
+              : '<span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs bg-zinc-100 dark:bg-zinc-800 text-zinc-500">Inactive</span>'
+            }
+          </h3>
+          <p class="text-xs text-zinc-500 mt-1">
+            Adds a <strong>Var</strong> toolbar button to the rich text editor for inserting global variables as inline chips. Works with both Quill and TinyMCE.
+          </p>
+        </div>
+        ${editorStatus.editorActive
+          ? `<button onclick="toggleEditorIntegration()" id="editor-toggle-btn"
+                    class="relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 ${editorStatus.enableEditorIntegration ? 'bg-blue-600' : 'bg-zinc-600'}"
+                    role="switch" aria-checked="${editorStatus.enableEditorIntegration}">
+              <span class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${editorStatus.enableEditorIntegration ? 'translate-x-5' : 'translate-x-0'}"></span>
+            </button>`
+          : ''
+        }
+      </div>
+      ${!editorStatus.editorActive
+        ? `<div class="mt-3 rounded-md bg-yellow-500/10 border border-yellow-500/20 px-4 py-3">
+            <div class="flex items-start gap-2">
+              <svg class="w-5 h-5 text-yellow-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z"/></svg>
+              <div>
+                <p class="text-sm font-medium text-yellow-600 dark:text-yellow-400">No rich text editor plugin is active</p>
+                <p class="text-xs text-yellow-600/80 dark:text-yellow-400/80 mt-0.5">
+                  To use variable insertion in the editor, enable either the <strong>Quill Editor</strong> or <strong>TinyMCE</strong> plugin from the
+                  <a href="/admin/plugins" class="underline hover:text-yellow-500">Plugins page</a>.
+                </p>
+              </div>
+            </div>
+          </div>`
+        : ''
+      }
+    </div>
+
+    <!-- API reference -->
+    <details class="mt-6">
+      <summary class="text-sm text-zinc-500 cursor-pointer hover:text-zinc-700 dark:hover:text-zinc-300">API Reference</summary>
+      <div class="mt-2 bg-zinc-100 dark:bg-zinc-900 rounded-lg border border-zinc-200 dark:border-zinc-800 p-4 text-sm text-zinc-600 dark:text-zinc-400 space-y-1">
+        <div><code>GET /api/global-variables</code> — List all</div>
+        <div><code>GET /api/global-variables/resolve</code> — Key→value map</div>
+        <div><code>POST /api/global-variables</code> — Create <code>{ key, value, description, category }</code></div>
+        <div><code>PUT /api/global-variables/:id</code> — Update <code>{ value, description, category, isActive }</code></div>
+        <div><code>DELETE /api/global-variables/:id</code> — Delete</div>
+      </div>
+    </details>
+
+    <!-- Toast container -->
+    <div id="toast" class="fixed bottom-6 right-6 z-50 hidden">
+      <div class="rounded-lg px-4 py-3 text-sm font-medium shadow-lg transition-all" id="toast-inner"></div>
+    </div>
+
+    <!-- JavaScript: save/delete/toggle via fetch (handles CSRF properly) -->
+    <script>
+      function showToast(message, type) {
+        var toast = document.getElementById('toast');
+        var inner = document.getElementById('toast-inner');
+        inner.textContent = message;
+        inner.className = 'rounded-lg px-4 py-3 text-sm font-medium shadow-lg transition-all ' +
+          (type === 'success' ? 'bg-green-600 text-white' :
+           type === 'error' ? 'bg-red-600 text-white' : 'bg-zinc-700 text-white');
+        toast.classList.remove('hidden');
+        setTimeout(function() { toast.classList.add('hidden'); }, 3000);
+      }
+
+      function markDirty(input) {
+        var row = input.closest('tr');
+        var original = row.getAttribute('data-original');
+        var saveBtn = row.querySelector('.save-btn');
+        var status = row.querySelector('.save-status');
+        if (input.value !== original) {
+          saveBtn.classList.remove('hidden');
+          status.textContent = '';
+          input.classList.add('border-yellow-500');
+        } else {
+          saveBtn.classList.add('hidden');
+          input.classList.remove('border-yellow-500');
+        }
+      }
+
+      async function saveVariable(id, btn) {
+        var row = document.getElementById('var-' + id);
+        var input = row.querySelector('.var-value-input');
+        var status = row.querySelector('.save-status');
+        btn.disabled = true;
+        btn.textContent = 'Saving...';
+        try {
+          var resp = await fetch('/api/global-variables/' + id, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ value: input.value })
+          });
+          var json = await resp.json();
+          if (json.success) {
+            row.setAttribute('data-original', input.value);
+            input.classList.remove('border-yellow-500');
+            btn.classList.add('hidden');
+            status.innerHTML = '<span class="text-green-500">Saved</span>';
+            showToast('Variable updated', 'success');
+            setTimeout(function() { status.textContent = ''; }, 2000);
+          } else {
+            showToast(json.error || 'Save failed', 'error');
+          }
+        } catch(e) {
+          showToast('Network error', 'error');
+        }
+        btn.disabled = false;
+        btn.textContent = 'Save';
+      }
+
+      async function toggleVariable(id) {
+        try {
+          // Get current state, flip it
+          var resp = await fetch('/api/global-variables/' + id);
+          var json = await resp.json();
+          if (!json.success) { showToast('Failed to load variable', 'error'); return; }
+          var newState = !json.data.isActive;
+          var resp2 = await fetch('/api/global-variables/' + id, {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ isActive: newState })
+          });
+          var json2 = await resp2.json();
+          if (json2.success) {
+            showToast(newState ? 'Activated' : 'Deactivated', 'success');
+            setTimeout(function() { location.reload(); }, 500);
+          } else {
+            showToast(json2.error || 'Toggle failed', 'error');
+          }
+        } catch(e) {
+          showToast('Network error', 'error');
+        }
+      }
+
+      async function deleteVariable(id, keyName) {
+        if (!confirm('Delete variable ' + keyName + '?')) return;
+        try {
+          var resp = await fetch('/api/global-variables/' + id, { method: 'DELETE' });
+          var json = await resp.json();
+          if (json.success) {
+            document.getElementById('var-' + id).remove();
+            showToast('Variable deleted', 'success');
+          } else {
+            showToast(json.error || 'Delete failed', 'error');
+          }
+        } catch(e) {
+          showToast('Network error', 'error');
+        }
+      }
+
+      async function toggleEditorIntegration() {
+        try {
+          var resp = await fetch('/admin/global-variables/settings/editor-integration', { method: 'POST' });
+          var json = await resp.json();
+          if (json.success) {
+            showToast(json.enableEditorIntegration ? 'Quill integration enabled' : 'Quill integration disabled', 'success');
+            setTimeout(function() { location.reload(); }, 500);
+          } else {
+            showToast(json.error || 'Failed to update', 'error');
+          }
+        } catch(e) {
+          showToast('Network error', 'error');
+        }
+      }
+
+      // Add form submit via fetch (not HTMX)
+      document.querySelector('form').addEventListener('submit', async function(e) {
+        e.preventDefault();
+        var form = e.target;
+        var data = {
+          key: form.key.value.trim(),
+          value: form.value.value.trim(),
+          category: form.category.value.trim() || 'general',
+          description: form.description.value.trim()
+        };
+        if (!data.key || !/^[a-z0-9_]+$/.test(data.key)) {
+          showToast('Key must be lowercase alphanumeric with underscores', 'error');
+          return;
+        }
+        try {
+          var resp = await fetch('/api/global-variables', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(data)
+          });
+          var json = await resp.json();
+          if (json.success) {
+            showToast('Variable created', 'success');
+            setTimeout(function() { location.reload(); }, 500);
+          } else {
+            showToast(json.error || 'Create failed', 'error');
+          }
+        } catch(e) {
+          showToast('Network error', 'error');
+        }
+      });
+    </script>
   </div>
-</body>
-</html>`
+  ` })
 }
 
-function escapeHtml(str: string): string {
-  return str
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-}
+// ─── Plugin Builder ──────────────────────────────────────────────────────────
 
-// ============================================================================
-// Plugin Builder
-// ============================================================================
-
-export function createGlobalVariablesPlugin(): Plugin {
+export function createGlobalVariablesPlugin() {
   const builder = PluginBuilder.create({
     name: 'global-variables',
-    version: '1.0.0-beta.1',
-    description: 'Dynamic content variables with inline token support for rich text fields',
+    version: '1.1.0',
+    description: 'Dynamic content variables with inline token support and CRUD admin page',
   })
 
   builder.metadata({
-    author: { name: 'SonicJS Team', email: 'team@sonicjs.com' },
+    author: { name: 'SonicJS Community', email: 'community@sonicjs.com' },
     license: 'MIT',
     compatibility: '^2.0.0',
   })
 
-  // Database model
-  builder.addModel('GlobalVariable', {
-    tableName: 'global_variables',
-    schema: globalVariableSchema,
-    migrations: [globalVariablesMigration],
-  })
-
-  // API routes
   builder.addRoute('/api/global-variables', apiRoutes, {
     description: 'Global variables CRUD API',
     requiresAuth: true,
     priority: 50,
   })
 
-  // Admin page
   builder.addRoute('/admin/global-variables', adminRoutes, {
-    description: 'Global variables admin page',
+    description: 'Global variables admin page with full CRUD',
     requiresAuth: true,
     priority: 50,
   })
 
-  // Menu item
   builder.addMenuItem('Global Variables', '/admin/global-variables', {
     icon: 'variable',
     order: 45,
     permissions: ['global-variables:view'],
   })
 
-  // Hook: resolve variables in content on read
   builder.addHook('content:read', async (data: any, context: any) => {
     try {
       const db = context?.context?.env?.DB
       if (!db || !data) return data
-
       const variables = await getVariablesMap(db)
       if (variables.size === 0) return data
-
       return resolveVariablesInObject(data, variables)
     } catch {
-      // Don't break content reads if resolution fails
       return data
     }
   }, {
@@ -484,40 +707,156 @@ export function createGlobalVariablesPlugin(): Plugin {
     description: 'Resolve {variable_key} tokens in content data',
   })
 
-  // Lifecycle
   builder.lifecycle({
-    activate: async (ctx: any) => {
-      // Run migration to create table
-      try {
-        const db = ctx?.env?.DB
-        if (db) {
-          // Split migration into individual statements
-          const statements = globalVariablesMigration
-            .split(';')
-            .map((s: string) => s.trim())
-            .filter((s: string) => s.length > 0)
-
-          for (const statement of statements) {
-            await db.prepare(statement).run()
-          }
-          console.info('[GlobalVariables] Table created/verified')
-        }
-      } catch (error) {
-        console.error('[GlobalVariables] Migration error:', error)
+    install: async (ctx: any) => {
+      const db = ctx?.env?.DB
+      if (db) {
+        const statements = MIGRATION_SQL.split(';').map(s => s.trim()).filter(s => s.length > 0)
+        for (const stmt of statements) { await db.prepare(stmt).run() }
+        console.info('[GlobalVariables] Tables created')
       }
+    },
+    activate: async () => {
       console.info('[GlobalVariables] Plugin activated')
     },
     deactivate: async () => {
-      invalidateCache()
-      console.info('[GlobalVariables] Plugin deactivated')
+      invalidateVariablesCache()
+      console.info('[GlobalVariables] Plugin deactivated, cache cleared')
+    },
+    uninstall: async (ctx: any) => {
+      const db = ctx?.env?.DB
+      if (db) {
+        await db.prepare('DROP TABLE IF EXISTS global_variables').run()
+        console.info('[GlobalVariables] Tables dropped')
+      }
     },
   })
 
-  return builder.build() as Plugin
+  return builder.build()
 }
 
 export const globalVariablesPlugin = createGlobalVariablesPlugin()
 
-// Re-export resolver for direct use
+// Export raw route handlers for direct mounting
+export { apiRoutes as globalVariablesApiRoutes, adminRoutes as globalVariablesAdminRoutes }
+
+// Re-export resolver
 export { resolveVariables, resolveVariablesInObject } from './variable-resolver'
-export { getVariablesMap, invalidateCache }
+
+// ─── Quill Blot Integration ─────────────────────────────────────────────────
+// Self-contained Variable blot for the Quill editor.
+// Returns injectable HTML (styles + scripts) that registers a VariableBlot
+// and adds a "Var" toolbar button with a searchable picker dropdown.
+//
+// Depends on shared infrastructure from quill-shared.ts (picker, proxy, poller).
+// The shared code is idempotent — safe to include from both plugins.
+
+export function getVariableBlotScript(): string {
+  return getSharedQuillStyles() + getSharedQuillScript() + `
+    <script>
+    (function() {
+      function waitForQuill(cb) {
+        if (typeof Quill !== 'undefined') return cb();
+        setTimeout(function() { waitForQuill(cb); }, 50);
+      }
+
+      waitForQuill(function() {
+        // ─── Register Variable Blot ────────────────────────────────
+        var Embed = Quill.import('blots/embed');
+
+        function VariableBlot() {
+          return Reflect.construct(Embed, arguments, VariableBlot);
+        }
+        Object.setPrototypeOf(VariableBlot.prototype, Embed.prototype);
+        Object.setPrototypeOf(VariableBlot, Embed);
+
+        VariableBlot.blotName = 'variable';
+        VariableBlot.tagName = 'SPAN';
+        VariableBlot.className = 'ql-variable-blot';
+
+        VariableBlot.create = function(value) {
+          var node = Embed.create.call(this);
+          var key = (value && value.key) ? value.key : (typeof value === 'string' ? value : '');
+          node.setAttribute('data-variable-key', key);
+          node.setAttribute('contenteditable', 'false');
+          node.innerText = key;
+          return node;
+        };
+
+        VariableBlot.value = function(node) {
+          return { key: node.getAttribute('data-variable-key') || '' };
+        };
+
+        Quill.register(VariableBlot, true);
+
+        // ─── Register toolbar enhancer ─────────────────────────────
+        window.__sonicQuillEnhancers = window.__sonicQuillEnhancers || [];
+        window.__sonicQuillEnhancers.push(function(container, quill, toolbar) {
+          // Skip if already added
+          if (toolbar.querySelector('.ql-insertVariable')) return;
+
+          var shared = window.__sonicQuillShared;
+          var varBtn = document.createElement('button');
+          varBtn.className = 'ql-insertVariable';
+          varBtn.type = 'button';
+          varBtn.innerHTML = '\\u{1f524} Var';
+          varBtn.title = 'Insert Global Variable';
+          varBtn.addEventListener('click', function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            var savedRange = quill.getSelection() || { index: quill.getLength() - 1 };
+            shared.showPicker({
+              button: varBtn,
+              icon: '\\u{1f524}',
+              label: 'variables',
+              apiUrl: '/api/global-variables?active=true',
+              filterActive: false,
+              renderItem: function(item) {
+                return '<span class="item-key" style="color:#60a5fa">{' + item.key + '}</span>'
+                     + '<span class="item-value">' + ((item.value || '') + '').substring(0, 40) + '</span>';
+              },
+              getSearchText: function(item) {
+                return item.key + ' ' + (item.value || '') + ' ' + (item.description || '') + ' ' + (item.category || '');
+              },
+              onSelect: function(item) {
+                shared.insertBlot(quill, savedRange.index, 'variable', { key: item.key });
+              }
+            });
+          });
+
+          var sep = document.createElement('span');
+          sep.className = 'ql-formats';
+          sep.appendChild(varBtn);
+          toolbar.appendChild(sep);
+        });
+      });
+    })();
+    </script>
+  ` + getQuillEnhancerPollerScript();
+}
+
+// ─── TinyMCE Integration ────────────────────────────────────────────────────
+// Self-contained Variable integration for the TinyMCE editor.
+// Adds a "Var" toolbar button, renders variables as noneditable chips,
+// serializes back to {key} syntax on save.
+
+export function getVariableTinyMceScript(): string {
+  return getSharedTinyMceStyles() + getTinyMcePluginScript({
+    buttonName: 'sonicInsertVar',
+    buttonText: '\\u{1f524} Var',
+    buttonTooltip: 'Insert Global Variable',
+    pickerIcon: '\\u{1f524}',
+    pickerLabel: 'variables',
+    pickerApiUrl: '/api/global-variables?active=true',
+    renderItemJs: `function(item) {
+      return '<span class="item-key" style="color:#60a5fa">{' + item.key + '}</span>'
+           + '<span class="item-value">' + ((item.value || '') + '').substring(0, 40) + '</span>';
+    }`,
+    getSearchTextJs: `function(item) {
+      return item.key + ' ' + (item.value || '') + ' ' + (item.description || '') + ' ' + (item.category || '');
+    }`,
+    onSelectJs: `function(editor, item) {
+      editor.insertContent('<span class="sonic-var-chip" contenteditable="false" data-var-key="' + item.key + '">' + item.key + '</span>&nbsp;');
+    }`,
+  });
+}

--- a/packages/core/src/plugins/core-plugins/global-variables-plugin/manifest.json
+++ b/packages/core/src/plugins/core-plugins/global-variables-plugin/manifest.json
@@ -1,14 +1,14 @@
 {
   "id": "global-variables",
   "name": "Global Variables",
-  "version": "1.0.0-beta.1",
-  "description": "Dynamic content variables that can be referenced as inline tokens in rich text fields. Supports {variable_key} syntax with server-side resolution.",
-  "author": "SonicJS Team",
+  "version": "1.1.0",
+  "description": "Dynamic content variables with inline token support. Manage key-value variables via admin UI and use {variable_key} syntax in rich text fields for server-side resolution. Includes full CRUD admin page.",
+  "author": "SonicJS Community",
   "homepage": "https://sonicjs.com/plugins/global-variables",
   "repository": "https://github.com/SonicJs-Org/sonicjs",
   "license": "MIT",
   "category": "content",
-  "tags": ["variables", "tokens", "dynamic-content", "rich-text", "globals"],
+  "tags": ["variables", "tokens", "dynamic-content", "rich-text", "globals", "admin"],
   "dependencies": [],
   "settings": {
     "enableResolution": true,
@@ -17,11 +17,30 @@
   },
   "hooks": {
     "onActivate": "activate",
-    "onDeactivate": "deactivate"
+    "onDeactivate": "deactivate",
+    "onInstall": "install",
+    "onUninstall": "uninstall"
   },
-  "routes": [],
+  "routes": [
+    {
+      "path": "/api/global-variables",
+      "description": "CRUD API for global variables",
+      "requiresAuth": true
+    },
+    {
+      "path": "/admin/global-variables",
+      "description": "Admin page for managing global variables",
+      "requiresAuth": true
+    }
+  ],
   "permissions": {
-    "global-variables:manage": "Manage global variables",
-    "global-variables:view": "View global variables"
+    "global-variables:manage": "Create, update, and delete global variables",
+    "global-variables:view": "View global variables and their values"
+  },
+  "adminMenu": {
+    "label": "Global Variables",
+    "icon": "variable",
+    "path": "/admin/global-variables",
+    "order": 45
   }
 }

--- a/packages/core/src/plugins/core-plugins/index.ts
+++ b/packages/core/src/plugins/core-plugins/index.ts
@@ -28,6 +28,13 @@ export { oauthProvidersPlugin, createOAuthProvidersPlugin } from './oauth-provid
 export { OAuthService, BUILT_IN_PROVIDERS } from './oauth-providers/oauth-service'
 export { globalVariablesPlugin, createGlobalVariablesPlugin } from './global-variables-plugin'
 export { resolveVariables, resolveVariablesInObject } from './global-variables-plugin'
+export { getVariableBlotScript, getVariableTinyMceScript } from './global-variables-plugin'
+export { shortcodesPlugin, createShortcodesPlugin } from './shortcodes-plugin'
+export { resolveShortcodes, resolveShortcodesInObject, registerShortcodeHandler } from './shortcodes-plugin'
+export { getShortcodeBlotScript, getShortcodeTinyMceScript } from './shortcodes-plugin'
+export { wrapAdminPage } from './_shared/admin-template'
+export { getSharedQuillStyles, getSharedQuillScript, getQuillEnhancerPollerScript } from './_shared/quill-shared'
+export { getSharedTinyMceStyles, getTinyMcePluginScript } from './_shared/tinymce-shared'
 export { securityAuditPlugin, createSecurityAuditPlugin } from './security-audit-plugin'
 export { SecurityAuditService, BruteForceDetector, securityAuditMiddleware } from './security-audit-plugin'
 export { userProfilesPlugin, createUserProfilesPlugin, defineUserProfile, getUserProfileConfig } from './user-profiles'
@@ -52,6 +59,7 @@ export const CORE_PLUGIN_IDS = [
   'ai-search',
   'oauth-providers',
   'global-variables',
+  'shortcodes',
   'security-audit',
   'user-profiles'
 ] as const

--- a/packages/core/src/plugins/core-plugins/shortcodes-plugin/index.ts
+++ b/packages/core/src/plugins/core-plugins/shortcodes-plugin/index.ts
@@ -1,0 +1,742 @@
+/**
+ * Shortcodes Plugin
+ *
+ * Registered shortcode functions for dynamic content in rich text fields.
+ * Use [[shortcode_name param="value"]] syntax — resolved server-side on content read.
+ *
+ * Features:
+ * - Handler registry for custom shortcode functions
+ * - CRUD API for managing shortcode definitions
+ * - Admin page with handler status badges and live preview
+ * - content:read hook for automatic resolution
+ * - Built-in handlers: current_date, phone_link, cta_button, plan_count, provider_rating
+ *
+ * @see https://github.com/lane711/sonicjs/issues/719 (shortcodes mentioned as future extension)
+ */
+
+import { Hono } from 'hono'
+import { PluginBuilder } from '../../../sdk/plugin-builder'
+import { wrapAdminPage } from '../_shared/admin-template'
+import {
+  resolveShortcodesInObject,
+  resolveShortcodes,
+  getRegisteredHandlers,
+  hasHandler,
+} from './shortcode-resolver'
+import {
+  getSharedQuillStyles,
+  getSharedQuillScript,
+  getQuillEnhancerPollerScript,
+} from '../_shared/quill-shared'
+import {
+  getSharedTinyMceStyles,
+  getTinyMcePluginScript,
+} from '../_shared/tinymce-shared'
+
+// Re-export for consumers
+export { registerShortcodeHandler, getRegisteredHandlers } from './shortcode-resolver'
+
+// ─── Migration SQL ───────────────────────────────────────────────────────────
+
+const MIGRATION_SQL = `
+CREATE TABLE IF NOT EXISTS shortcodes (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  name TEXT NOT NULL UNIQUE,
+  display_name TEXT NOT NULL DEFAULT '',
+  description TEXT,
+  category TEXT DEFAULT 'general',
+  handler_key TEXT NOT NULL,
+  default_params TEXT DEFAULT '{}',
+  example_usage TEXT,
+  is_active INTEGER NOT NULL DEFAULT 1,
+  created_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now')),
+  updated_at INTEGER NOT NULL DEFAULT (strftime('%s', 'now'))
+);
+CREATE UNIQUE INDEX IF NOT EXISTS idx_shortcodes_name ON shortcodes(name);
+CREATE INDEX IF NOT EXISTS idx_shortcodes_category ON shortcodes(category);
+CREATE INDEX IF NOT EXISTS idx_shortcodes_active ON shortcodes(is_active);
+`
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function formatShortcode(row: any) {
+  if (!row) return null
+  let defaultParams = {}
+  try { defaultParams = typeof row.default_params === 'string' ? JSON.parse(row.default_params) : (row.default_params || {}) } catch { /* */ }
+  return {
+    id: row.id,
+    name: row.name,
+    displayName: row.display_name,
+    description: row.description,
+    category: row.category,
+    handlerKey: row.handler_key,
+    defaultParams: defaultParams,
+    exampleUsage: row.example_usage,
+    isActive: row.is_active === 1 || row.is_active === true,
+    handlerRegistered: hasHandler(row.handler_key),
+    createdAt: row.created_at,
+    updatedAt: row.updated_at,
+  }
+}
+
+function esc(s: string): string {
+  return (s || '').replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}
+
+// ─── API Routes ──────────────────────────────────────────────────────────────
+
+const apiRoutes = new Hono()
+
+apiRoutes.use('*', async (c: any, next: any) => {
+  try {
+    const db = c.env?.DB
+    if (db) {
+      const row = await db.prepare("SELECT status FROM plugins WHERE id = 'shortcodes' AND status = 'active'").first()
+      if (!row) return c.json({ error: 'Plugin not active' }, 404)
+    }
+  } catch { /* allow */ }
+  await next()
+})
+
+apiRoutes.get('/', async (c: any) => {
+  try {
+    const db = c.env.DB
+    const active = c.req.query('active')
+    const resolvable = c.req.query('resolvable')
+    let query = 'SELECT * FROM shortcodes'
+    const params: any[] = []
+    if (active !== undefined) { query += ' WHERE is_active = ?'; params.push(active === 'true' ? 1 : 0) }
+    query += ' ORDER BY category ASC, name ASC'
+
+    const { results } = await db.prepare(query).bind(...params).all()
+    let data = (results || []).map(formatShortcode)
+
+    // Filter to only shortcodes with registered handlers (resolvable on content read)
+    if (resolvable === 'true') {
+      data = data.filter((sc: any) => sc.handlerRegistered)
+    }
+
+    return c.json({ success: true, data })
+  } catch {
+    return c.json({ success: false, error: 'Failed to fetch shortcodes' }, 500)
+  }
+})
+
+apiRoutes.get('/handlers/registered', async (c: any) => {
+  return c.json({ success: true, data: getRegisteredHandlers() })
+})
+
+apiRoutes.post('/preview', async (c: any) => {
+  try {
+    const { text } = await c.req.json()
+    if (!text) return c.json({ error: 'text is required' }, 400)
+    const output = await resolveShortcodes(text)
+    return c.json({ success: true, data: { input: text, output } })
+  } catch {
+    return c.json({ success: false, error: 'Failed to preview shortcode' }, 500)
+  }
+})
+
+apiRoutes.get('/:id', async (c: any) => {
+  try {
+    const result = await c.env.DB.prepare('SELECT * FROM shortcodes WHERE id = ?').bind(c.req.param('id')).first()
+    if (!result) return c.json({ error: 'Shortcode not found' }, 404)
+    return c.json({ success: true, data: formatShortcode(result) })
+  } catch {
+    return c.json({ success: false, error: 'Failed to fetch shortcode' }, 500)
+  }
+})
+
+apiRoutes.post('/', async (c: any) => {
+  try {
+    const db = c.env.DB
+    const { name, display_name, displayName, description, handler_key, handlerKey, default_params, defaultParams, example_usage, exampleUsage, category } = await c.req.json()
+    const scName = name
+    const scHandlerKey = handler_key || handlerKey
+    const scDisplayName = display_name || displayName || scName
+    const scDefaultParams = default_params || defaultParams || {}
+    const scExampleUsage = example_usage || exampleUsage || ''
+
+    if (!scName || !/^\w+$/.test(scName)) return c.json({ error: 'Name must be alphanumeric with underscores' }, 400)
+    if (!scHandlerKey) return c.json({ error: 'handler_key is required' }, 400)
+
+    const existing = await db.prepare('SELECT id FROM shortcodes WHERE name = ?').bind(scName).first()
+    if (existing) return c.json({ error: `Shortcode "${scName}" already exists` }, 409)
+
+    await db.prepare(
+      'INSERT INTO shortcodes (name, display_name, description, handler_key, default_params, example_usage, category) VALUES (?, ?, ?, ?, ?, ?, ?)'
+    ).bind(scName, scDisplayName, description || '', scHandlerKey, JSON.stringify(scDefaultParams), scExampleUsage, category || 'general').run()
+
+    const created = await db.prepare('SELECT * FROM shortcodes WHERE name = ?').bind(scName).first()
+    return c.json({ success: true, data: formatShortcode(created) }, 201)
+  } catch {
+    return c.json({ success: false, error: 'Failed to create shortcode' }, 500)
+  }
+})
+
+apiRoutes.put('/:id', async (c: any) => {
+  try {
+    const db = c.env.DB
+    const id = c.req.param('id')
+    const existing = await db.prepare('SELECT * FROM shortcodes WHERE id = ?').bind(id).first()
+    if (!existing) return c.json({ error: 'Shortcode not found' }, 404)
+
+    const body = await c.req.json()
+    const updates: string[] = []
+    const params: any[] = []
+
+    if (body.display_name !== undefined || body.displayName !== undefined) { updates.push('display_name = ?'); params.push(body.display_name || body.displayName) }
+    if (body.description !== undefined) { updates.push('description = ?'); params.push(body.description) }
+    if (body.handler_key !== undefined || body.handlerKey !== undefined) { updates.push('handler_key = ?'); params.push(body.handler_key || body.handlerKey) }
+    if (body.default_params !== undefined || body.defaultParams !== undefined) { updates.push('default_params = ?'); params.push(JSON.stringify(body.default_params || body.defaultParams)) }
+    if (body.example_usage !== undefined || body.exampleUsage !== undefined) { updates.push('example_usage = ?'); params.push(body.example_usage || body.exampleUsage) }
+    if (body.category !== undefined) { updates.push('category = ?'); params.push(body.category) }
+    if (body.isActive !== undefined || body.is_active !== undefined) { updates.push('is_active = ?'); params.push((body.isActive ?? body.is_active) ? 1 : 0) }
+
+    if (updates.length === 0) return c.json({ error: 'No fields to update' }, 400)
+    updates.push('updated_at = strftime(\'%s\', \'now\')')
+    params.push(id)
+    await db.prepare(`UPDATE shortcodes SET ${updates.join(', ')} WHERE id = ?`).bind(...params).run()
+
+    const updated = await db.prepare('SELECT * FROM shortcodes WHERE id = ?').bind(id).first()
+    return c.json({ success: true, data: formatShortcode(updated) })
+  } catch {
+    return c.json({ success: false, error: 'Failed to update shortcode' }, 500)
+  }
+})
+
+apiRoutes.delete('/:id', async (c: any) => {
+  try {
+    const db = c.env.DB
+    const id = c.req.param('id')
+    const existing = await db.prepare('SELECT id FROM shortcodes WHERE id = ?').bind(id).first()
+    if (!existing) return c.json({ error: 'Shortcode not found' }, 404)
+    await db.prepare('DELETE FROM shortcodes WHERE id = ?').bind(id).run()
+    return c.json({ success: true })
+  } catch {
+    return c.json({ success: false, error: 'Failed to delete shortcode' }, 500)
+  }
+})
+
+// ─── Admin Page ──────────────────────────────────────────────────────────────
+
+const adminRoutes = new Hono()
+
+adminRoutes.use('*', async (c: any, next: any) => {
+  try {
+    const db = c.env?.DB
+    if (db) {
+      const row = await db.prepare("SELECT status FROM plugins WHERE id = 'shortcodes' AND status = 'active'").first()
+      if (!row) return c.html('<html><body><h1>Plugin not active</h1><p>Enable the Shortcodes plugin from <a href="/admin/plugins">Plugins</a>.</p></body></html>', 404)
+    }
+  } catch { /* allow */ }
+  await next()
+})
+
+adminRoutes.get('/', async (c: any) => {
+  const db = c.env.DB
+  let shortcodes: any[] = []
+  try {
+    const { results } = await db.prepare('SELECT * FROM shortcodes ORDER BY category ASC, name ASC').all()
+    shortcodes = (results || []).map(formatShortcode)
+  } catch { /* table may not exist */ }
+
+  // Fetch editor integration status
+  let editorActive = false
+  let activeEditorName = ''
+  let enableEditorIntegration = true
+  try {
+    const qeRow = await db.prepare("SELECT status FROM plugins WHERE (id = 'quill-editor' OR name = 'quill-editor') AND status = 'active'").first()
+    const tmRow = await db.prepare("SELECT status FROM plugins WHERE (id = 'tinymce-plugin' OR name = 'tinymce-plugin') AND status = 'active'").first()
+    if (qeRow) { editorActive = true; activeEditorName = 'Quill Editor' }
+    else if (tmRow) { editorActive = true; activeEditorName = 'TinyMCE' }
+    const scRow = await db.prepare("SELECT settings FROM plugins WHERE id = 'shortcodes'").first() as any
+    if (scRow?.settings) {
+      const settings = typeof scRow.settings === 'string' ? JSON.parse(scRow.settings) : scRow.settings
+      enableEditorIntegration = settings.enableEditorIntegration !== false
+    }
+  } catch { /* ignore */ }
+
+  return c.html(renderAdminPage(shortcodes, { editorActive, activeEditorName, enableEditorIntegration }))
+})
+
+// HTMX: create
+adminRoutes.post('/', async (c: any) => {
+  const db = c.env.DB
+  const form = await c.req.parseBody()
+  const name = (form.name as string || '').trim()
+  const displayName = (form.display_name as string || name).trim()
+  const handlerKey = (form.handler_key as string || '').trim()
+  const category = (form.category as string || 'general').trim()
+  const description = (form.description as string || '').trim()
+  const exampleUsage = (form.example_usage as string || '').trim()
+
+  if (!name || !/^\w+$/.test(name)) {
+    return c.html('<div class="bg-red-500/10 border border-red-500/30 text-red-400 text-sm rounded-lg px-4 py-2 mb-4">Name must be alphanumeric with underscores</div>')
+  }
+  if (!handlerKey) {
+    return c.html('<div class="bg-red-500/10 border border-red-500/30 text-red-400 text-sm rounded-lg px-4 py-2 mb-4">Handler is required</div>')
+  }
+
+  await db.prepare(
+    'INSERT OR IGNORE INTO shortcodes (name, display_name, description, handler_key, default_params, example_usage, category) VALUES (?, ?, ?, ?, \'{}\', ?, ?)'
+  ).bind(name, displayName, description, handlerKey, exampleUsage, category).run()
+
+  c.header('HX-Redirect', '/admin/shortcodes')
+  return c.body(null, 204)
+})
+
+// Toggle editor integration setting
+adminRoutes.post('/settings/editor-integration', async (c: any) => {
+  const db = c.env.DB
+  try {
+    const row = await db.prepare("SELECT settings FROM plugins WHERE id = 'shortcodes'").first() as any
+    const settings = row?.settings ? (typeof row.settings === 'string' ? JSON.parse(row.settings) : row.settings) : {}
+    settings.enableEditorIntegration = !settings.enableEditorIntegration
+    await db.prepare("UPDATE plugins SET settings = ? WHERE id = 'shortcodes'").bind(JSON.stringify(settings)).run()
+    return c.json({ success: true, enableEditorIntegration: settings.enableEditorIntegration })
+  } catch {
+    return c.json({ success: false, error: 'Failed to update setting' }, 500)
+  }
+})
+
+// HTMX: delete
+adminRoutes.delete('/:id', async (c: any) => {
+  await c.env.DB.prepare('DELETE FROM shortcodes WHERE id = ?').bind(c.req.param('id')).run()
+  return c.html('')
+})
+
+// ─── Admin Page Template ─────────────────────────────────────────────────────
+
+function renderAdminPage(shortcodes: any[], editorStatus: { editorActive: boolean; activeEditorName: string; enableEditorIntegration: boolean } = { editorActive: false, activeEditorName: '', enableEditorIntegration: true }): string {
+  const groups = new Map<string, any[]>()
+  for (const sc of shortcodes) {
+    const cat = sc.category || 'general'
+    if (!groups.has(cat)) groups.set(cat, [])
+    groups.get(cat)!.push(sc)
+  }
+
+  const handlers = getRegisteredHandlers()
+
+  const categoryHtml = Array.from(groups.entries()).map(([cat, scs]) => `
+    <div class="mb-6">
+      <h3 class="text-xs font-semibold text-zinc-500 uppercase tracking-wider mb-2 flex items-center gap-2">
+        <span class="w-1.5 h-1.5 rounded-full bg-purple-500"></span>
+        ${esc(cat)} <span class="text-zinc-600">(${scs.length})</span>
+      </h3>
+      <div class="space-y-2">
+        ${scs.map(sc => `
+          <div class="bg-white dark:bg-zinc-900 rounded-lg border border-zinc-200 dark:border-zinc-800 p-4 group" id="sc-${sc.id}">
+            <div class="flex items-start justify-between gap-4">
+              <div class="flex-1 min-w-0">
+                <div class="flex items-center gap-2 mb-1">
+                  <span class="text-sm font-semibold">${esc(sc.displayName || sc.name)}</span>
+                  <code class="text-xs font-mono text-purple-600 dark:text-purple-400 bg-purple-50 dark:bg-purple-500/10 rounded px-1.5 py-0.5">[[${esc(sc.name)}]]</code>
+                  <span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs ${sc.isActive ? 'bg-green-500/10 text-green-600 dark:text-green-400' : 'bg-zinc-100 dark:bg-zinc-800 text-zinc-500'}">
+                    ${sc.isActive ? 'Active' : 'Off'}
+                  </span>
+                  ${sc.handlerRegistered
+                    ? '<span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs bg-blue-500/10 text-blue-600 dark:text-blue-400" title="Resolves to inline HTML on content read">Resolvable</span>'
+                    : '<span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs bg-red-500/10 text-red-600 dark:text-red-400" title="No handler registered — will not resolve in content">No handler</span>'
+                  }
+                </div>
+                ${sc.description ? `<p class="text-xs text-zinc-500 mb-1">${esc(sc.description)}</p>` : ''}
+                ${sc.exampleUsage ? `<code class="text-xs font-mono text-zinc-500 bg-zinc-50 dark:bg-zinc-800 rounded px-2 py-0.5">${esc(sc.exampleUsage)}</code>` : ''}
+              </div>
+              <button hx-delete="/admin/shortcodes/${sc.id}" hx-confirm="Delete shortcode '${esc(sc.name)}'?"
+                      hx-target="#sc-${sc.id}" hx-swap="outerHTML"
+                      class="rounded p-1.5 text-zinc-400 hover:text-red-500 hover:bg-red-50 dark:hover:bg-red-500/10 opacity-0 group-hover:opacity-100 transition-all">
+                <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"/></svg>
+              </button>
+            </div>
+          </div>
+        `).join('')}
+      </div>
+    </div>
+  `).join('')
+
+  const handlerOptions = handlers.map(h => `<option value="${h}">${h}</option>`).join('')
+
+  return wrapAdminPage({ title: 'Shortcodes', body: `
+  <div class="max-w-4xl mx-auto px-6 py-8">
+    <div class="flex items-center justify-between mb-6">
+      <div>
+        <div class="flex items-center gap-2 mb-1">
+          <a href="/admin/dashboard" class="text-zinc-400 hover:text-zinc-600 dark:hover:text-zinc-300 transition-colors">
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M15 19l-7-7 7-7"/></svg>
+          </a>
+          <h1 class="text-2xl font-bold">Shortcodes</h1>
+        </div>
+        <p class="text-sm text-zinc-500">
+          Inline content functions. Use <code class="text-purple-600 dark:text-purple-400 bg-purple-50 dark:bg-purple-500/10 px-1.5 py-0.5 rounded text-xs">[[shortcode_name param="value"]]</code> in rich text — each resolves to an inline HTML string on content read. Only shortcodes with registered handlers are available in the Quill editor picker.
+        </p>
+      </div>
+      <div class="text-sm text-zinc-500">${shortcodes.length} shortcode${shortcodes.length !== 1 ? 's' : ''} &middot; ${handlers.length} handler${handlers.length !== 1 ? 's' : ''}</div>
+    </div>
+
+    <div id="shortcodes-list">
+      ${categoryHtml || `
+        <div class="bg-white dark:bg-zinc-900 rounded-lg border border-zinc-200 dark:border-zinc-800 p-12 text-center">
+          <div class="text-4xl mb-3">⚡</div>
+          <h3 class="text-lg font-medium mb-1">No shortcodes yet</h3>
+          <p class="text-sm text-zinc-500">Register a shortcode below.</p>
+        </div>
+      `}
+    </div>
+
+    <!-- Add shortcode form -->
+    <div class="mt-6 bg-white dark:bg-zinc-900 rounded-lg border border-zinc-200 dark:border-zinc-800 p-5">
+      <h3 class="text-sm font-semibold mb-3">Register Shortcode</h3>
+      <form hx-post="/admin/shortcodes" hx-target="#form-errors" hx-swap="innerHTML" class="space-y-3">
+        <div id="form-errors"></div>
+        <div class="grid grid-cols-12 gap-3">
+          <div class="col-span-3">
+            <label class="block text-xs text-zinc-500 mb-1">Name</label>
+            <input type="text" name="name" required pattern="\\w+" placeholder="my_shortcode"
+                   class="w-full rounded-md border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800 px-3 py-2 text-sm font-mono placeholder-zinc-400 focus:border-purple-500 focus:ring-1 focus:ring-purple-500" />
+          </div>
+          <div class="col-span-3">
+            <label class="block text-xs text-zinc-500 mb-1">Display Name</label>
+            <input type="text" name="display_name" required placeholder="My Shortcode"
+                   class="w-full rounded-md border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800 px-3 py-2 text-sm placeholder-zinc-400 focus:border-purple-500 focus:ring-1 focus:ring-purple-500" />
+          </div>
+          <div class="col-span-3">
+            <label class="block text-xs text-zinc-500 mb-1">Handler</label>
+            <select name="handler_key" required
+                    class="w-full rounded-md border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800 px-3 py-2 text-sm focus:border-purple-500 focus:ring-1 focus:ring-purple-500">
+              <option value="">Select...</option>
+              ${handlerOptions}
+            </select>
+          </div>
+          <div class="col-span-2">
+            <label class="block text-xs text-zinc-500 mb-1">Category</label>
+            <input type="text" name="category" value="general"
+                   class="w-full rounded-md border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800 px-3 py-2 text-sm placeholder-zinc-400 focus:border-purple-500 focus:ring-1 focus:ring-purple-500" />
+          </div>
+          <div class="col-span-1 flex items-end">
+            <button type="submit" class="w-full rounded-md bg-zinc-900 dark:bg-white px-3 py-2 text-sm font-medium text-white dark:text-zinc-900 hover:bg-zinc-800 dark:hover:bg-zinc-100 transition-colors">
+              Add
+            </button>
+          </div>
+        </div>
+      </form>
+    </div>
+
+    <!-- Preview -->
+    <div class="mt-6 bg-white dark:bg-zinc-900 rounded-lg border border-zinc-200 dark:border-zinc-800 p-5">
+      <h3 class="text-sm font-semibold mb-3">Preview</h3>
+      <div class="flex gap-3">
+        <input type="text" id="preview-input" placeholder='[[current_date format="MM/DD/YYYY"]]'
+               class="flex-1 rounded-md border border-zinc-200 dark:border-zinc-700 bg-zinc-50 dark:bg-zinc-800 px-3 py-2 text-sm font-mono placeholder-zinc-400 focus:border-purple-500 focus:ring-1 focus:ring-purple-500" />
+        <button onclick="previewShortcode()" class="rounded-md bg-zinc-200 dark:bg-zinc-800 px-4 py-2 text-sm hover:bg-zinc-300 dark:hover:bg-zinc-700 transition-colors">Preview</button>
+      </div>
+      <div id="preview-output" class="mt-3 bg-zinc-50 dark:bg-zinc-800 rounded-md p-3 text-sm hidden"></div>
+    </div>
+
+    <script>
+      async function previewShortcode() {
+        var input = document.getElementById('preview-input').value;
+        if (!input) return;
+        var resp = await fetch('/api/shortcodes/preview', {
+          method: 'POST', headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ text: input })
+        });
+        var json = await resp.json();
+        var output = document.getElementById('preview-output');
+        output.classList.remove('hidden');
+        output.innerHTML = '<span class="text-zinc-500 text-xs">Output:</span><br>' + (json.data?.output || json.error || 'No output');
+      }
+    </script>
+
+    <!-- Rich Text Editor Integration -->
+    <div class="mt-6 bg-white dark:bg-zinc-900 rounded-lg border border-zinc-200 dark:border-zinc-800 p-5">
+      <div class="flex items-center justify-between">
+        <div>
+          <h3 class="text-sm font-semibold flex items-center gap-2">
+            Rich Text Editor Integration
+            ${editorStatus.editorActive && editorStatus.enableEditorIntegration
+              ? `<span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs bg-green-500/10 text-green-600 dark:text-green-400">Active — ${esc(editorStatus.activeEditorName)}</span>`
+              : '<span class="inline-flex items-center rounded-full px-2 py-0.5 text-xs bg-zinc-100 dark:bg-zinc-800 text-zinc-500">Inactive</span>'
+            }
+          </h3>
+          <p class="text-xs text-zinc-500 mt-1">
+            Adds an <strong>SC</strong> toolbar button to the rich text editor for inserting shortcodes as inline chips. Works with both Quill and TinyMCE.
+          </p>
+        </div>
+        ${editorStatus.editorActive
+          ? `<button onclick="toggleEditorIntegration()" id="editor-toggle-btn"
+                    class="relative inline-flex h-6 w-11 flex-shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus:ring-2 focus:ring-purple-500 focus:ring-offset-2 ${editorStatus.enableEditorIntegration ? 'bg-purple-600' : 'bg-zinc-600'}"
+                    role="switch" aria-checked="${editorStatus.enableEditorIntegration}">
+              <span class="pointer-events-none inline-block h-5 w-5 transform rounded-full bg-white shadow ring-0 transition duration-200 ease-in-out ${editorStatus.enableEditorIntegration ? 'translate-x-5' : 'translate-x-0'}"></span>
+            </button>`
+          : ''
+        }
+      </div>
+      ${!editorStatus.editorActive
+        ? `<div class="mt-3 rounded-md bg-yellow-500/10 border border-yellow-500/20 px-4 py-3">
+            <div class="flex items-start gap-2">
+              <svg class="w-5 h-5 text-yellow-500 mt-0.5 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z"/></svg>
+              <div>
+                <p class="text-sm font-medium text-yellow-600 dark:text-yellow-400">No rich text editor plugin is active</p>
+                <p class="text-xs text-yellow-600/80 dark:text-yellow-400/80 mt-0.5">
+                  To use shortcode insertion in the editor, enable either the <strong>Quill Editor</strong> or <strong>TinyMCE</strong> plugin from the
+                  <a href="/admin/plugins" class="underline hover:text-yellow-500">Plugins page</a>.
+                </p>
+              </div>
+            </div>
+          </div>`
+        : ''
+      }
+    </div>
+
+    <script>
+      async function toggleEditorIntegration() {
+        try {
+          var resp = await fetch('/admin/shortcodes/settings/editor-integration', { method: 'POST' });
+          var json = await resp.json();
+          if (json.success) {
+            var toast = document.createElement('div');
+            toast.className = 'fixed bottom-6 right-6 z-50 rounded-lg px-4 py-3 text-sm font-medium shadow-lg bg-green-600 text-white';
+            toast.textContent = json.enableEditorIntegration ? 'Editor integration enabled' : 'Editor integration disabled';
+            document.body.appendChild(toast);
+            setTimeout(function() { location.reload(); }, 500);
+          }
+        } catch(e) {
+          alert('Network error');
+        }
+      }
+    </script>
+
+    <details class="mt-6">
+      <summary class="text-sm text-zinc-500 cursor-pointer hover:text-zinc-700 dark:hover:text-zinc-300">API Reference</summary>
+      <div class="mt-2 bg-zinc-100 dark:bg-zinc-900 rounded-lg border border-zinc-200 dark:border-zinc-800 p-4 text-sm text-zinc-600 dark:text-zinc-400 space-y-1">
+        <div><code>GET /api/shortcodes</code> — List all</div>
+        <div><code>GET /api/shortcodes/handlers/registered</code> — Handler keys</div>
+        <div><code>POST /api/shortcodes/preview</code> — Live preview</div>
+        <div><code>POST /api/shortcodes</code> — Create</div>
+        <div><code>PUT /api/shortcodes/:id</code> — Update</div>
+        <div><code>DELETE /api/shortcodes/:id</code> — Delete</div>
+      </div>
+    </details>
+  </div>
+  ` })
+}
+
+// ─── Plugin Builder ──────────────────────────────────────────────────────────
+
+export function createShortcodesPlugin() {
+  const builder = PluginBuilder.create({
+    name: 'shortcodes',
+    version: '1.0.0',
+    description: 'Registered shortcode functions for dynamic content with [[shortcode]] syntax',
+  })
+
+  builder.metadata({
+    author: { name: 'SonicJS Community', email: 'community@sonicjs.com' },
+    license: 'MIT',
+    compatibility: '^2.0.0',
+  })
+
+  builder.addRoute('/api/shortcodes', apiRoutes, {
+    description: 'Shortcodes CRUD API + preview + handler list',
+    requiresAuth: true,
+    priority: 50,
+  })
+
+  builder.addRoute('/admin/shortcodes', adminRoutes, {
+    description: 'Shortcodes admin page with CRUD and preview',
+    requiresAuth: true,
+    priority: 50,
+  })
+
+  builder.addMenuItem('Shortcodes', '/admin/shortcodes', {
+    icon: 'bolt',
+    order: 46,
+    permissions: ['shortcodes:view'],
+  })
+
+  builder.addHook('content:read', async (data: any, context: any) => {
+    try {
+      if (!data) return data
+      return resolveShortcodesInObject(data, context)
+    } catch {
+      return data
+    }
+  }, {
+    priority: 60, // Run after global-variables (50)
+    description: 'Resolve [[shortcode]] tokens in content data',
+  })
+
+  builder.lifecycle({
+    install: async (ctx: any) => {
+      const db = ctx?.env?.DB
+      if (db) {
+        const statements = MIGRATION_SQL.split(';').map(s => s.trim()).filter(s => s.length > 0)
+        for (const stmt of statements) { await db.prepare(stmt).run() }
+        console.info('[Shortcodes] Tables created')
+      }
+    },
+    activate: async () => {
+      console.info('[Shortcodes] Plugin activated')
+    },
+    deactivate: async () => {
+      console.info('[Shortcodes] Plugin deactivated')
+    },
+    uninstall: async (ctx: any) => {
+      const db = ctx?.env?.DB
+      if (db) {
+        await db.prepare('DROP TABLE IF EXISTS shortcodes').run()
+        console.info('[Shortcodes] Tables dropped')
+      }
+    },
+  })
+
+  return builder.build()
+}
+
+export const shortcodesPlugin = createShortcodesPlugin()
+
+// Export raw route handlers for direct mounting
+export { apiRoutes as shortcodesApiRoutes, adminRoutes as shortcodesAdminRoutes }
+
+// Re-export resolver
+export { resolveShortcodes, resolveShortcodesInObject } from './shortcode-resolver'
+
+// ─── Quill Blot Integration ─────────────────────────────────────────────────
+// Self-contained Shortcode blot for the Quill editor.
+// Returns injectable HTML (styles + scripts) that registers a ShortcodeBlot
+// and adds a "SC" toolbar button with a searchable picker dropdown.
+//
+// Depends on shared infrastructure from quill-shared.ts (picker, proxy, poller).
+// The shared code is idempotent — safe to include from both plugins.
+
+export function getShortcodeBlotScript(): string {
+  return getSharedQuillStyles() + getSharedQuillScript() + `
+    <script>
+    (function() {
+      function waitForQuill(cb) {
+        if (typeof Quill !== 'undefined') return cb();
+        setTimeout(function() { waitForQuill(cb); }, 50);
+      }
+
+      waitForQuill(function() {
+        // ─── Register Shortcode Blot ───────────────────────────────
+        var Embed = Quill.import('blots/embed');
+
+        function ShortcodeBlot() {
+          return Reflect.construct(Embed, arguments, ShortcodeBlot);
+        }
+        Object.setPrototypeOf(ShortcodeBlot.prototype, Embed.prototype);
+        Object.setPrototypeOf(ShortcodeBlot, Embed);
+
+        ShortcodeBlot.blotName = 'shortcode';
+        ShortcodeBlot.tagName = 'SPAN';
+        ShortcodeBlot.className = 'ql-shortcode-blot';
+
+        ShortcodeBlot.create = function(value) {
+          var node = Embed.create.call(this);
+          var name = (value && value.name) ? value.name : (typeof value === 'string' ? value : '');
+          var params = (value && value.params) ? value.params : '';
+          node.setAttribute('data-shortcode-name', name);
+          if (params) node.setAttribute('data-shortcode-params', params);
+          node.setAttribute('contenteditable', 'false');
+          node.innerText = name + (params ? ' ' + params : '');
+          return node;
+        };
+
+        ShortcodeBlot.value = function(node) {
+          return {
+            name: node.getAttribute('data-shortcode-name') || '',
+            params: node.getAttribute('data-shortcode-params') || ''
+          };
+        };
+
+        Quill.register(ShortcodeBlot, true);
+
+        // ─── Register toolbar enhancer ─────────────────────────────
+        window.__sonicQuillEnhancers = window.__sonicQuillEnhancers || [];
+        window.__sonicQuillEnhancers.push(function(container, quill, toolbar) {
+          // Skip if already added
+          if (toolbar.querySelector('.ql-insertShortcode')) return;
+
+          var shared = window.__sonicQuillShared;
+          var scBtn = document.createElement('button');
+          scBtn.className = 'ql-insertShortcode';
+          scBtn.type = 'button';
+          scBtn.innerHTML = '\\u26A1 SC';
+          scBtn.title = 'Insert Shortcode';
+          scBtn.addEventListener('click', function(e) {
+            e.preventDefault();
+            e.stopPropagation();
+            var savedRange = quill.getSelection() || { index: quill.getLength() - 1 };
+            shared.showPicker({
+              button: scBtn,
+              icon: '\\u26A1',
+              label: 'shortcodes',
+              apiUrl: '/api/shortcodes?active=true&resolvable=true',
+              filterActive: false,
+              renderItem: function(item) {
+                return '<span class="item-key" style="color:#c084fc">[[' + item.name + ']]</span>'
+                     + '<span class="item-value">' + (item.display_name || item.name) + '</span>';
+              },
+              getSearchText: function(item) {
+                return item.name + ' ' + (item.display_name || '') + ' ' + (item.description || '') + ' ' + (item.category || '');
+              },
+              onSelect: function(item) {
+                var params = '';
+                try {
+                  var dp = typeof item.default_params === 'string' ? JSON.parse(item.default_params) : (item.default_params || {});
+                  var paramParts = [];
+                  Object.keys(dp).forEach(function(k) { paramParts.push(k + '="' + dp[k] + '"'); });
+                  if (paramParts.length) params = paramParts.join(' ');
+                } catch(ex) {}
+                shared.insertBlot(quill, savedRange.index, 'shortcode', { name: item.name, params: params });
+              }
+            });
+          });
+
+          var sep = document.createElement('span');
+          sep.className = 'ql-formats';
+          sep.appendChild(scBtn);
+          toolbar.appendChild(sep);
+        });
+      });
+    })();
+    </script>
+  ` + getQuillEnhancerPollerScript();
+}
+
+// ─── TinyMCE Integration ────────────────────────────────────────────────────
+// Self-contained Shortcode integration for the TinyMCE editor.
+// Adds a "SC" toolbar button, renders shortcodes as noneditable chips,
+// serializes back to [[name params]] syntax on save.
+
+export function getShortcodeTinyMceScript(): string {
+  return getSharedTinyMceStyles() + getTinyMcePluginScript({
+    buttonName: 'sonicInsertSC',
+    buttonText: '\\u26A1 SC',
+    buttonTooltip: 'Insert Shortcode',
+    pickerIcon: '\\u26A1',
+    pickerLabel: 'shortcodes',
+    pickerApiUrl: '/api/shortcodes?active=true&resolvable=true',
+    renderItemJs: `function(item) {
+      return '<span class="item-key" style="color:#c084fc">[[' + item.name + ']]</span>'
+           + '<span class="item-value">' + (item.display_name || item.name) + '</span>';
+    }`,
+    getSearchTextJs: `function(item) {
+      return item.name + ' ' + (item.display_name || '') + ' ' + (item.description || '') + ' ' + (item.category || '');
+    }`,
+    onSelectJs: `function(editor, item) {
+      var params = '';
+      try {
+        var dp = typeof item.default_params === 'string' ? JSON.parse(item.default_params) : (item.default_params || {});
+        var pp = [];
+        Object.keys(dp).forEach(function(k) { pp.push(k + '="' + dp[k] + '"'); });
+        if (pp.length) params = pp.join(' ');
+      } catch(ex) {}
+      var label = item.name + (params ? ' ' + params : '');
+      var pa = params ? ' data-sc-params="' + params.replace(/"/g, '&amp;quot;') + '"' : '';
+      editor.insertContent('<span class="sonic-sc-chip" contenteditable="false" data-sc-name="' + item.name + '"' + pa + '>' + label + '</span>&nbsp;');
+    }`,
+  });
+}

--- a/packages/core/src/plugins/core-plugins/shortcodes-plugin/manifest.json
+++ b/packages/core/src/plugins/core-plugins/shortcodes-plugin/manifest.json
@@ -1,0 +1,45 @@
+{
+  "id": "shortcodes",
+  "name": "Shortcodes",
+  "version": "1.0.0",
+  "description": "Registered shortcode functions for dynamic content. Use [[shortcode_name param=\"value\"]] syntax in rich text fields for server-side resolution. Includes handler registry, CRUD admin, and live preview.",
+  "author": "SonicJS Community",
+  "homepage": "https://sonicjs.com/plugins/shortcodes",
+  "repository": "https://github.com/SonicJs-Org/sonicjs",
+  "license": "MIT",
+  "category": "content",
+  "tags": ["shortcodes", "dynamic-content", "rich-text", "functions", "templates"],
+  "dependencies": [],
+  "settings": {
+    "enableResolution": true,
+    "cacheEnabled": true
+  },
+  "hooks": {
+    "onActivate": "activate",
+    "onDeactivate": "deactivate",
+    "onInstall": "install",
+    "onUninstall": "uninstall"
+  },
+  "routes": [
+    {
+      "path": "/api/shortcodes",
+      "description": "Shortcodes CRUD API + preview + handler list",
+      "requiresAuth": true
+    },
+    {
+      "path": "/admin/shortcodes",
+      "description": "Admin page for managing shortcodes",
+      "requiresAuth": true
+    }
+  ],
+  "permissions": {
+    "shortcodes:manage": "Create, update, and delete shortcodes",
+    "shortcodes:view": "View shortcodes and their definitions"
+  },
+  "adminMenu": {
+    "label": "Shortcodes",
+    "icon": "bolt",
+    "path": "/admin/shortcodes",
+    "order": 46
+  }
+}

--- a/packages/core/src/plugins/core-plugins/shortcodes-plugin/shortcode-resolver.ts
+++ b/packages/core/src/plugins/core-plugins/shortcodes-plugin/shortcode-resolver.ts
@@ -1,0 +1,181 @@
+/**
+ * Shortcode Resolver
+ *
+ * Scans strings for [[shortcode_name param="value"]] tokens and replaces them
+ * by calling registered handler functions.
+ *
+ * Token syntax: [[name]] or [[name param1="value1" param2="value2"]]
+ * Unresolved shortcodes (no handler) are left as-is.
+ */
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type ShortcodeHandler = (
+  params: Record<string, string>,
+  context?: any
+) => string | Promise<string>
+
+// ─── Handler Registry ────────────────────────────────────────────────────────
+
+const handlerRegistry = new Map<string, ShortcodeHandler>()
+
+/**
+ * Register a shortcode handler function.
+ * Call this at module load time to make handlers available.
+ */
+export function registerShortcodeHandler(key: string, handler: ShortcodeHandler): void {
+  handlerRegistry.set(key, handler)
+}
+
+/**
+ * Get all registered handler keys.
+ */
+export function getRegisteredHandlers(): string[] {
+  return Array.from(handlerRegistry.keys())
+}
+
+/**
+ * Check if a handler is registered.
+ */
+export function hasHandler(key: string): boolean {
+  return handlerRegistry.has(key)
+}
+
+// ─── Parser ──────────────────────────────────────────────────────────────────
+
+const SHORTCODE_PATTERN = /\[\[(\w+)([^\]]*)\]\]/g
+
+/**
+ * Parse shortcode parameters from a string like: param1="value1" param2="value2"
+ */
+export function parseShortcodeParams(paramStr: string): Record<string, string> {
+  const params: Record<string, string> = {}
+  const regex = /(\w+)="([^"]*)"/g
+  let match
+  while ((match = regex.exec(paramStr)) !== null) {
+    params[match[1]] = match[2]
+  }
+  return params
+}
+
+// ─── Resolver ────────────────────────────────────────────────────────────────
+
+/**
+ * Resolve all [[shortcode]] tokens in a string.
+ * Calls registered handlers and replaces tokens with output.
+ * Unknown shortcodes are left as-is.
+ */
+export async function resolveShortcodes(
+  text: string,
+  context?: any
+): Promise<string> {
+  if (!text) return text
+  // Quick check before running regex
+  if (!text.includes('[[')) return text
+
+  SHORTCODE_PATTERN.lastIndex = 0
+  const replacements: Array<{ match: string; replacement: string }> = []
+
+  let m
+  while ((m = SHORTCODE_PATTERN.exec(text)) !== null) {
+    const name = m[1]
+    const paramStr = m[2]
+    const params = parseShortcodeParams(paramStr)
+    const handler = handlerRegistry.get(name)
+
+    if (handler) {
+      try {
+        const result = await handler(params, context)
+        // Handlers must return strings (inline HTML or plain text).
+        // This is the contract: shortcodes resolve to content that can
+        // live inside rich text — not components, not objects.
+        if (typeof result === 'string') {
+          replacements.push({ match: m[0], replacement: result })
+        } else {
+          replacements.push({ match: m[0], replacement: `<!-- shortcode ${name}: handler returned non-string -->` })
+        }
+      } catch {
+        replacements.push({ match: m[0], replacement: `<!-- shortcode error: ${name} -->` })
+      }
+    }
+    // Unknown shortcodes (no handler) left as-is
+  }
+
+  let result = text
+  for (const r of replacements) {
+    result = result.replace(r.match, r.replacement)
+  }
+  return result
+}
+
+/**
+ * Recursively resolve shortcodes in an object's string values.
+ */
+export async function resolveShortcodesInObject(
+  obj: any,
+  context?: any
+): Promise<any> {
+  if (!obj) return obj
+
+  if (typeof obj === 'string') {
+    return resolveShortcodes(obj, context)
+  }
+
+  if (Array.isArray(obj)) {
+    return Promise.all(obj.map(item => resolveShortcodesInObject(item, context)))
+  }
+
+  if (typeof obj === 'object') {
+    const result: Record<string, any> = {}
+    for (const [key, value] of Object.entries(obj)) {
+      result[key] = await resolveShortcodesInObject(value, context)
+    }
+    return result
+  }
+
+  return obj
+}
+
+// ─── Built-in Handlers ───────────────────────────────────────────────────────
+
+registerShortcodeHandler('current_date', (params) => {
+  const now = new Date()
+  const format = params.format || 'MMMM D, YYYY'
+  const months = ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December']
+  const monthsShort = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec']
+  return format
+    .replace('YYYY', String(now.getFullYear()))
+    .replace('YY', String(now.getFullYear()).slice(-2))
+    .replace('MMMM', months[now.getMonth()])
+    .replace('MMM', monthsShort[now.getMonth()])
+    .replace('MM', String(now.getMonth() + 1).padStart(2, '0'))
+    .replace('DD', String(now.getDate()).padStart(2, '0'))
+    .replace('D', String(now.getDate()))
+})
+
+registerShortcodeHandler('phone_link', (params) => {
+  const number = params.number || ''
+  const digits = number.replace(/\D/g, '')
+  return `<a href="tel:+1${digits}" class="text-blue-600 hover:underline">${number}</a>`
+})
+
+registerShortcodeHandler('cta_button', (params) => {
+  const text = params.text || 'Learn More'
+  const url = params.url || '/'
+  const style = params.style || 'primary'
+  const colors = style === 'primary'
+    ? 'bg-blue-600 hover:bg-blue-700 text-white'
+    : 'bg-zinc-200 hover:bg-zinc-300 text-zinc-900'
+  return `<a href="${url}" class="inline-block rounded-lg px-6 py-3 font-semibold ${colors} transition-colors">${text}</a>`
+})
+
+registerShortcodeHandler('plan_count', (params) => {
+  const type = params.type || 'residential'
+  return `<span data-shortcode="plan_count" data-type="${type}" class="font-semibold">1,000+</span>`
+})
+
+registerShortcodeHandler('provider_rating', (params) => {
+  const format = params.format || 'stars'
+  const display = format === 'numeric' ? '4.2/5' : '★★★★☆'
+  return `<span data-shortcode="provider_rating" data-provider="${params.provider || ''}" class="text-yellow-500">${display}</span>`
+})


### PR DESCRIPTION
## Summary

Implements **Part 2** (Rich Text Inline Tokens) from #719 and extends PR #743 with full rich text editor integration for both **Quill** and **TinyMCE** editors, plus a new **Shortcodes** plugin.

- Enhanced **global-variables-plugin** with full CRUD admin page, Quill variable blots (blue chips), TinyMCE toolbar button, and editor integration toggle
- New **shortcodes-plugin** with `[[shortcode_name param="value"]]` syntax, handler registry, CRUD admin with live preview, Quill shortcode blots (purple chips), and TinyMCE integration
- **Shared editor utilities** for Quill (constructor Proxy, searchable picker, enhancer poller) and TinyMCE (PluginManager approach, chip CSS injection)
- **Shared admin template** with Tailwind CSS, HTMX, and CSRF auto-injection

## Changes

### Enhanced: `global-variables-plugin` (3 files modified)
- **`index.ts`** — Complete rewrite with:
  - Full CRUD admin page (add, inline edit, delete, toggle active/inactive)
  - Plugin status gating (routes return 404 when plugin inactive)
  - `install`/`uninstall` lifecycle hooks for table management
  - `getVariableBlotScript()` — Quill integration with custom VariableBlot (blue chip), searchable picker
  - `getVariableTinyMceScript()` — TinyMCE integration via PluginManager.add()
  - Rich Text Editor Integration settings card with toggle + editor auto-detection
- **`manifest.json`** — Updated to v1.1.0 with admin menu, routes, and lifecycle hooks
- **`variable-resolver.ts`** — Unchanged (already solid from #743)

### New: `shortcodes-plugin` (3 files)
- **`index.ts`** — Full plugin with:
  - `[[shortcode_name param="value"]]` token syntax
  - CRUD API + admin page with handler status badges
  - Live preview endpoint (`POST /api/shortcodes/preview`)
  - `content:read` hook at priority 60 (runs after variables at 50)
  - `getShortcodeBlotScript()` — Quill integration with ShortcodeBlot (purple chip)
  - `getShortcodeTinyMceScript()` — TinyMCE integration via PluginManager.add()
- **`shortcode-resolver.ts`** — Parser + handler registry with 5 built-in handlers:
  - `current_date` — Formatted date output
  - `phone_link` — Clickable phone link
  - `cta_button` — Styled call-to-action button
  - `plan_count` — Dynamic plan count placeholder
  - `provider_rating` — Star rating display
- **`manifest.json`** — Plugin metadata

### New: `_shared/` directory (4 files)
- **`admin-template.ts`** — HTML wrapper with Tailwind + HTMX + CSRF
- **`quill-shared.ts`** — Quill constructor Proxy (custom format whitelisting), searchable picker dropdown, enhancer polling framework
- **`tinymce-shared.ts`** — TinyMCE PluginManager approach (official API), picker dropdown, chip CSS injection into editor iframe
- **`index.ts`** — Barrel exports

### Modified: `core-plugins/index.ts`
- Added exports for shortcodes plugin, editor scripts, and shared utilities
- Added `'shortcodes'` to `CORE_PLUGIN_IDS`

## How It Works

### Editor Integration Flow
1. Plugins export self-contained HTML (styles + scripts) via `get*BlotScript()` / `get*TinyMceScript()`
2. Host app injects these into admin content edit pages via `afterAuth` middleware
3. Scripts auto-detect which editor is active (Quill or TinyMCE) and register accordingly
4. Tokens render as styled chips in the editor; serialized back to `{key}` / `[[name]]` syntax on save

### Quill Approach
- Custom `Embed` blots (VariableBlot, ShortcodeBlot) registered via `Quill.register()`
- `Proxy` wraps Quill constructor to inject custom formats into the whitelist
- Toolbar buttons added via enhancer polling (waits for Quill instances to initialize)
- `text-change` handler serializes chips → tokens in hidden input

### TinyMCE Approach
- `tinymce.PluginManager.add()` — the official TinyMCE plugin API
- Server-side HTML replacement injects button names into toolbar + plugins arrays
- `SetContent` handler converts `{key}` → chip spans; `GetContent` handler reverses
- Chip CSS injected into editor iframe via `editor.on('init')`

### Content Resolution
- Variables resolved at priority 50 (synchronous string replacement)
- Shortcodes resolved at priority 60 (async handler execution)
- Opt-out: `?resolve_variables=false`, `?resolve_shortcodes=false`

## Testing

All changes were developed and tested against a full SonicJS instance with:
- 21 Quill editor E2E tests passing (variable + shortcode blots)
- 9 content API resolution tests passing
- TinyMCE PluginManager integration verified

## Related

- Closes #756
- Closes #719 (Part 2: Rich Text Inline Tokens)
- Extends #743 (Part 1 + 3: Global Variables backend)