### PR TITLE
fix: resolve issues #785, #786, #787, #788

### DIFF
--- a/packages/core/migrations/036_analytics_events.sql
+++ b/packages/core/migrations/036_analytics_events.sql
@@ -1,0 +1,22 @@
+-- Migration 036: Analytics Events Table
+-- Provides storage for user behavior event tracking (page views, custom events)
+
+CREATE TABLE IF NOT EXISTS analytics_events (
+    id TEXT PRIMARY KEY,
+    event TEXT NOT NULL,
+    category TEXT NOT NULL DEFAULT 'user-activity',
+    properties TEXT,
+    user_id TEXT,
+    session_id TEXT,
+    ip_address TEXT,
+    user_agent TEXT,
+    path TEXT,
+    created_at INTEGER NOT NULL DEFAULT (unixepoch())
+);
+
+CREATE INDEX IF NOT EXISTS idx_analytics_events_event ON analytics_events(event);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_category ON analytics_events(category);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_user_id ON analytics_events(user_id);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_session_id ON analytics_events(session_id);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_created_at ON analytics_events(created_at);
+CREATE INDEX IF NOT EXISTS idx_analytics_events_path ON analytics_events(path);

--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -43,6 +43,8 @@ import { securityAuditPlugin } from './plugins/core-plugins/security-audit-plugi
 import { securityAuditMiddleware } from './plugins/core-plugins/security-audit-plugin'
 import { stripePlugin } from './plugins/core-plugins/stripe-plugin'
 import { pluginMenuMiddleware } from './middleware/plugin-menu'
+import { analyticsPlugin } from './plugins/core-plugins/analytics'
+import { eventsApiRoutes } from './plugins/core-plugins/analytics/routes/api'
 import cachePlugin from './plugins/cache'
 import { faviconSvg } from './assets/favicon'
 import { setAppInstance } from './services/route-metadata'
@@ -253,6 +255,16 @@ export function createSonicJSApp(config: SonicJSConfig = {}): SonicJSApp {
       app.route(route.path, route.handler as any)
     }
   }
+
+  // Plugin routes - Analytics (must be before /admin/plugins catch-all)
+  if (analyticsPlugin.routes && analyticsPlugin.routes.length > 0) {
+    for (const route of analyticsPlugin.routes) {
+      app.route(route.path, route.handler as any)
+    }
+  }
+
+  // Public event tracking API — POST /api/events (open), GET /api/events (admin)
+  app.route('/api/events', eventsApiRoutes)
 
   // Plugin routes - Stripe (must be before /admin/plugins catch-all)
   if (stripePlugin.routes && stripePlugin.routes.length > 0) {

--- a/packages/core/src/middleware/csrf.ts
+++ b/packages/core/src/middleware/csrf.ts
@@ -122,6 +122,11 @@ const DEFAULT_EXEMPT_PATHS = [
   '/auth/accept-invitation',
   '/auth/reset-password',
   '/auth/request-password-reset',
+  '/auth/otp',
+  '/auth/magic-link',
+  '/auth/verify',
+  '/api/stripe/webhook',
+  '/api/events',
 ]
 
 /**
@@ -198,6 +203,15 @@ export function csrfProtection(options: CsrfOptions = {}) {
     // Bearer-only or API-key-only requests (no auth_token cookie) — exempt
     const authCookie = getCookie(c, 'auth_token')
     if (!authCookie) {
+      await next()
+      return
+    }
+
+    // Requests with an Authorization header use token-based auth — the cookie
+    // is incidental and CSRF protection is unnecessary (the attacker cannot
+    // forge the Authorization header from a cross-origin page).
+    const authHeader = c.req.header('Authorization')
+    if (authHeader) {
       await next()
       return
     }

--- a/packages/core/src/plugins/core-plugins/analytics/index.ts
+++ b/packages/core/src/plugins/core-plugins/analytics/index.ts
@@ -8,6 +8,7 @@ import { Hono } from 'hono'
 // import { z } from 'zod'
 import { PluginBuilder, PluginHelpers } from '../../sdk/plugin-builder'
 import { Plugin, HOOKS } from '@sonicjs-cms/core'
+import { analyticsAdminRoutes } from './routes/admin'
 
 export function createAnalyticsPlugin(): Plugin {
   const builder = PluginBuilder.create({
@@ -103,6 +104,13 @@ export function createAnalyticsPlugin(): Plugin {
     requiresAuth: true,
     roles: ['admin', 'analytics:read'],
     priority: 3
+  })
+
+  // Admin dashboard routes
+  builder.addRoute('/admin/analytics', analyticsAdminRoutes as any, {
+    description: 'Analytics admin dashboard',
+    requiresAuth: true,
+    priority: 50
   })
 
   // Add analytics tracking middleware

--- a/packages/core/src/plugins/core-plugins/analytics/index.ts
+++ b/packages/core/src/plugins/core-plugins/analytics/index.ts
@@ -7,7 +7,8 @@
 import { Hono } from 'hono'
 // import { z } from 'zod'
 import { PluginBuilder, PluginHelpers } from '../../sdk/plugin-builder'
-import { Plugin, HOOKS } from '@sonicjs-cms/core'
+import type { Plugin } from '../../types'
+import { HOOKS } from '../../types'
 import { analyticsAdminRoutes } from './routes/admin'
 
 export function createAnalyticsPlugin(): Plugin {

--- a/packages/core/src/plugins/core-plugins/analytics/routes/admin.ts
+++ b/packages/core/src/plugins/core-plugins/analytics/routes/admin.ts
@@ -1,0 +1,160 @@
+import { Hono } from 'hono'
+import { requireAuth } from '../../../../middleware'
+import { renderAdminLayoutCatalyst } from '../../../../templates/layouts/admin-layout-catalyst.template'
+import type { Bindings, Variables } from '../../../../app'
+
+const adminRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>()
+
+adminRoutes.use('*', requireAuth())
+
+adminRoutes.use('*', async (c, next) => {
+  const user = c.get('user')
+  if (user?.role !== 'admin') {
+    return c.text('Access denied', 403)
+  }
+  return next()
+})
+
+// Analytics Dashboard
+adminRoutes.get('/', async (c) => {
+  const user = c.get('user')
+  const db = c.env.DB
+
+  // Query real metrics from system_logs
+  let totalRequests = 0
+  let uniqueIPs = 0
+  let avgDuration = 0
+  let errorCount = 0
+  let topPages: Array<{ path: string; views: number }> = []
+  let recentActivity: Array<{ url: string; method: string; status_code: number; duration: number; created_at: number }> = []
+
+  try {
+    const now = Math.floor(Date.now() / 1000)
+    const dayAgo = now - 86400
+
+    const [requestsResult, ipsResult, durationResult, errorsResult, pagesResult, activityResult] = await Promise.all([
+      db.prepare('SELECT COUNT(*) as count FROM system_logs WHERE category = ? AND created_at > ?')
+        .bind('api', dayAgo).first() as Promise<{ count: number } | null>,
+      db.prepare('SELECT COUNT(DISTINCT ip_address) as count FROM system_logs WHERE category = ? AND created_at > ?')
+        .bind('api', dayAgo).first() as Promise<{ count: number } | null>,
+      db.prepare('SELECT AVG(duration) as avg FROM system_logs WHERE category = ? AND created_at > ? AND duration IS NOT NULL')
+        .bind('api', dayAgo).first() as Promise<{ avg: number } | null>,
+      db.prepare('SELECT COUNT(*) as count FROM system_logs WHERE level IN (?, ?) AND created_at > ?')
+        .bind('error', 'fatal', dayAgo).first() as Promise<{ count: number } | null>,
+      db.prepare('SELECT url, COUNT(*) as views FROM system_logs WHERE category = ? AND created_at > ? AND url IS NOT NULL GROUP BY url ORDER BY views DESC LIMIT 10')
+        .bind('api', dayAgo).all(),
+      db.prepare('SELECT url, method, status_code, duration, created_at FROM system_logs WHERE category = ? ORDER BY created_at DESC LIMIT 20')
+        .bind('api').all(),
+    ])
+
+    totalRequests = requestsResult?.count || 0
+    uniqueIPs = ipsResult?.count || 0
+    avgDuration = Math.round(durationResult?.avg || 0)
+    errorCount = errorsResult?.count || 0
+    topPages = (pagesResult.results || []).map((r: any) => ({ path: r.url, views: r.views }))
+    recentActivity = (activityResult.results || []) as any[]
+  } catch {
+    // Tables may not exist yet
+  }
+
+  const content = `
+    <div class="space-y-8">
+      <div>
+        <h1 class="text-2xl font-semibold text-zinc-950 dark:text-white">Analytics Dashboard</h1>
+        <p class="mt-1 text-sm text-zinc-500 dark:text-zinc-400">Last 24 hours overview from system logs</p>
+      </div>
+
+      <!-- Stats Cards -->
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <div class="rounded-lg bg-white dark:bg-zinc-800 p-6 ring-1 ring-zinc-950/5 dark:ring-white/10">
+          <p class="text-sm font-medium text-zinc-500 dark:text-zinc-400">Total Requests</p>
+          <p class="mt-2 text-3xl font-semibold text-zinc-950 dark:text-white">${totalRequests.toLocaleString()}</p>
+        </div>
+        <div class="rounded-lg bg-white dark:bg-zinc-800 p-6 ring-1 ring-zinc-950/5 dark:ring-white/10">
+          <p class="text-sm font-medium text-zinc-500 dark:text-zinc-400">Unique Visitors</p>
+          <p class="mt-2 text-3xl font-semibold text-zinc-950 dark:text-white">${uniqueIPs.toLocaleString()}</p>
+        </div>
+        <div class="rounded-lg bg-white dark:bg-zinc-800 p-6 ring-1 ring-zinc-950/5 dark:ring-white/10">
+          <p class="text-sm font-medium text-zinc-500 dark:text-zinc-400">Avg Response Time</p>
+          <p class="mt-2 text-3xl font-semibold text-zinc-950 dark:text-white">${avgDuration}ms</p>
+        </div>
+        <div class="rounded-lg bg-white dark:bg-zinc-800 p-6 ring-1 ring-zinc-950/5 dark:ring-white/10">
+          <p class="text-sm font-medium text-zinc-500 dark:text-zinc-400">Errors</p>
+          <p class="mt-2 text-3xl font-semibold ${errorCount > 0 ? 'text-red-600 dark:text-red-400' : 'text-zinc-950 dark:text-white'}">${errorCount.toLocaleString()}</p>
+        </div>
+      </div>
+
+      <!-- Top Pages -->
+      <div class="rounded-lg bg-white dark:bg-zinc-800 ring-1 ring-zinc-950/5 dark:ring-white/10">
+        <div class="px-6 py-4 border-b border-zinc-950/5 dark:border-white/10">
+          <h2 class="text-lg font-semibold text-zinc-950 dark:text-white">Top Pages</h2>
+        </div>
+        <div class="divide-y divide-zinc-950/5 dark:divide-white/10">
+          ${topPages.length > 0 ? topPages.map(p => `
+            <div class="flex items-center justify-between px-6 py-3">
+              <span class="text-sm text-zinc-700 dark:text-zinc-300 font-mono truncate">${escapeHtml(p.path)}</span>
+              <span class="text-sm font-medium text-zinc-500 dark:text-zinc-400">${p.views}</span>
+            </div>
+          `).join('') : `
+            <div class="px-6 py-8 text-center text-sm text-zinc-500 dark:text-zinc-400">
+              No page views recorded yet. Analytics data will appear once requests are logged.
+            </div>
+          `}
+        </div>
+      </div>
+
+      <!-- Recent Activity -->
+      <div class="rounded-lg bg-white dark:bg-zinc-800 ring-1 ring-zinc-950/5 dark:ring-white/10">
+        <div class="px-6 py-4 border-b border-zinc-950/5 dark:border-white/10">
+          <h2 class="text-lg font-semibold text-zinc-950 dark:text-white">Recent Activity</h2>
+        </div>
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead class="bg-zinc-50 dark:bg-zinc-800/50">
+              <tr>
+                <th class="px-6 py-2 text-left font-medium text-zinc-500 dark:text-zinc-400">Path</th>
+                <th class="px-6 py-2 text-left font-medium text-zinc-500 dark:text-zinc-400">Method</th>
+                <th class="px-6 py-2 text-left font-medium text-zinc-500 dark:text-zinc-400">Status</th>
+                <th class="px-6 py-2 text-left font-medium text-zinc-500 dark:text-zinc-400">Duration</th>
+              </tr>
+            </thead>
+            <tbody class="divide-y divide-zinc-950/5 dark:divide-white/10">
+              ${recentActivity.length > 0 ? recentActivity.map(a => `
+                <tr>
+                  <td class="px-6 py-2 font-mono text-zinc-700 dark:text-zinc-300 truncate max-w-xs">${escapeHtml(a.url || '')}</td>
+                  <td class="px-6 py-2"><span class="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium ${a.method === 'GET' ? 'bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400' : 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-400'}">${a.method || ''}</span></td>
+                  <td class="px-6 py-2"><span class="inline-flex items-center rounded px-1.5 py-0.5 text-xs font-medium ${(a.status_code || 0) >= 400 ? 'bg-red-50 text-red-700 dark:bg-red-900/30 dark:text-red-400' : 'bg-green-50 text-green-700 dark:bg-green-900/30 dark:text-green-400'}">${a.status_code || ''}</span></td>
+                  <td class="px-6 py-2 text-zinc-500 dark:text-zinc-400">${a.duration || 0}ms</td>
+                </tr>
+              `).join('') : `
+                <tr>
+                  <td colspan="4" class="px-6 py-8 text-center text-zinc-500 dark:text-zinc-400">No activity recorded yet.</td>
+                </tr>
+              `}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  `
+
+  return c.html(renderAdminLayoutCatalyst({
+    title: 'Analytics',
+    pageTitle: 'Analytics Dashboard',
+    currentPath: '/admin/analytics',
+    version: c.get('appVersion'),
+    user: user ? {
+      name: user.email.split('@')[0] || 'Admin',
+      email: user.email,
+      role: user.role
+    } : undefined,
+    content,
+    dynamicMenuItems: c.get('pluginMenuItems')
+  }))
+})
+
+function escapeHtml(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;')
+}
+
+export { adminRoutes as analyticsAdminRoutes }

--- a/packages/core/src/plugins/core-plugins/analytics/routes/api.ts
+++ b/packages/core/src/plugins/core-plugins/analytics/routes/api.ts
@@ -1,0 +1,113 @@
+import { Hono } from 'hono'
+import { EventTrackingService } from '../services/event-tracking-service'
+import type { Bindings, Variables } from '../../../../app'
+
+const apiRoutes = new Hono<{ Bindings: Bindings; Variables: Variables }>()
+
+// POST /api/events - Track a single event or batch of events
+apiRoutes.post('/', async (c) => {
+  const db = c.env.DB
+  const service = new EventTrackingService(db)
+
+  const ip = c.req.header('cf-connecting-ip')
+    || c.req.header('x-forwarded-for')?.split(',')[0]?.trim()
+    || 'unknown'
+  const userAgent = c.req.header('user-agent') || ''
+  const user = c.get('user')
+
+  let body: any
+  try {
+    body = await c.req.json()
+  } catch {
+    return c.json({ error: 'Invalid JSON body' }, 400)
+  }
+
+  // Batch support: accept an array of events
+  if (Array.isArray(body)) {
+    if (body.length > 100) {
+      return c.json({ error: 'Batch size limit is 100 events' }, 400)
+    }
+
+    const events = body.map(e => ({
+      event: e.event,
+      category: e.category || 'user-activity',
+      properties: e.properties,
+      userId: user?.userId || e.userId,
+      sessionId: e.sessionId,
+      ipAddress: ip,
+      userAgent,
+      path: e.path
+    }))
+
+    // Validate all events have an event name
+    const invalid = events.find(e => !e.event || typeof e.event !== 'string')
+    if (invalid) {
+      return c.json({ error: 'Each event must have an "event" string field' }, 400)
+    }
+
+    const ids = await service.trackBatch(events)
+    return c.json({ success: true, eventIds: ids, count: ids.length })
+  }
+
+  // Single event
+  if (!body.event || typeof body.event !== 'string') {
+    return c.json({ error: '"event" field is required and must be a string' }, 400)
+  }
+
+  const eventId = await service.trackEvent({
+    event: body.event,
+    category: body.category || 'user-activity',
+    properties: body.properties,
+    userId: user?.userId || body.userId,
+    sessionId: body.sessionId,
+    ipAddress: ip,
+    userAgent,
+    path: body.path
+  })
+
+  return c.json({ success: true, eventId })
+})
+
+// GET /api/events - Query events (admin only)
+apiRoutes.get('/', async (c) => {
+  const user = c.get('user')
+  if (!user || user.role !== 'admin') {
+    return c.json({ error: 'Admin access required' }, 403)
+  }
+
+  const db = c.env.DB
+  const service = new EventTrackingService(db)
+
+  const filters = {
+    event: c.req.query('event') || undefined,
+    category: c.req.query('category') || undefined,
+    userId: c.req.query('userId') || undefined,
+    sessionId: c.req.query('sessionId') || undefined,
+    startDate: c.req.query('startDate') ? parseInt(c.req.query('startDate')!) : undefined,
+    endDate: c.req.query('endDate') ? parseInt(c.req.query('endDate')!) : undefined,
+    limit: c.req.query('limit') ? parseInt(c.req.query('limit')!) : 50,
+    offset: c.req.query('offset') ? parseInt(c.req.query('offset')!) : 0
+  }
+
+  const result = await service.queryEvents(filters)
+  return c.json(result)
+})
+
+// GET /api/events/stats - Aggregated event stats (admin only)
+apiRoutes.get('/stats', async (c) => {
+  const user = c.get('user')
+  if (!user || user.role !== 'admin') {
+    return c.json({ error: 'Admin access required' }, 403)
+  }
+
+  const db = c.env.DB
+  const service = new EventTrackingService(db)
+
+  const startDate = c.req.query('startDate') ? parseInt(c.req.query('startDate')!) : undefined
+  const endDate = c.req.query('endDate') ? parseInt(c.req.query('endDate')!) : undefined
+
+  const stats = await service.getStats(startDate, endDate)
+  return c.json(stats)
+})
+
+export { apiRoutes as eventsApiRoutes }

--- a/packages/core/src/plugins/core-plugins/analytics/services/event-tracking-service.ts
+++ b/packages/core/src/plugins/core-plugins/analytics/services/event-tracking-service.ts
@@ -1,0 +1,168 @@
+import type { D1Database } from '@cloudflare/workers-types'
+
+export interface TrackEventInput {
+  event: string
+  properties?: Record<string, unknown>
+  userId?: string
+  sessionId?: string
+  ipAddress?: string
+  userAgent?: string
+  path?: string
+  category?: string
+}
+
+export interface EventQueryFilters {
+  event?: string
+  category?: string
+  userId?: string
+  sessionId?: string
+  startDate?: number
+  endDate?: number
+  limit?: number
+  offset?: number
+}
+
+export interface EventStats {
+  totalEvents: number
+  uniqueUsers: number
+  uniqueSessions: number
+  topEvents: Array<{ event: string; count: number }>
+}
+
+export class EventTrackingService {
+  constructor(private db: D1Database) {}
+
+  async trackEvent(input: TrackEventInput): Promise<string> {
+    const id = crypto.randomUUID()
+    const category = input.category || 'user-activity'
+
+    await this.db.prepare(`
+      INSERT INTO analytics_events (id, event, category, properties, user_id, session_id, ip_address, user_agent, path)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).bind(
+      id,
+      input.event,
+      category,
+      input.properties ? JSON.stringify(input.properties) : null,
+      input.userId || null,
+      input.sessionId || null,
+      input.ipAddress || null,
+      input.userAgent || null,
+      input.path || null
+    ).run()
+
+    return id
+  }
+
+  async trackBatch(events: TrackEventInput[]): Promise<string[]> {
+    const ids: string[] = []
+
+    const stmts = events.map(input => {
+      const id = crypto.randomUUID()
+      ids.push(id)
+      const category = input.category || 'user-activity'
+
+      return this.db.prepare(`
+        INSERT INTO analytics_events (id, event, category, properties, user_id, session_id, ip_address, user_agent, path)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).bind(
+        id,
+        input.event,
+        category,
+        input.properties ? JSON.stringify(input.properties) : null,
+        input.userId || null,
+        input.sessionId || null,
+        input.ipAddress || null,
+        input.userAgent || null,
+        input.path || null
+      )
+    })
+
+    await this.db.batch(stmts)
+    return ids
+  }
+
+  async queryEvents(filters: EventQueryFilters = {}): Promise<{ events: any[]; total: number }> {
+    const conditions: string[] = []
+    const params: any[] = []
+
+    if (filters.event) {
+      conditions.push('event = ?')
+      params.push(filters.event)
+    }
+    if (filters.category) {
+      conditions.push('category = ?')
+      params.push(filters.category)
+    }
+    if (filters.userId) {
+      conditions.push('user_id = ?')
+      params.push(filters.userId)
+    }
+    if (filters.sessionId) {
+      conditions.push('session_id = ?')
+      params.push(filters.sessionId)
+    }
+    if (filters.startDate) {
+      conditions.push('created_at >= ?')
+      params.push(filters.startDate)
+    }
+    if (filters.endDate) {
+      conditions.push('created_at <= ?')
+      params.push(filters.endDate)
+    }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+    const limit = filters.limit || 50
+    const offset = filters.offset || 0
+
+    const [countResult, eventsResult] = await Promise.all([
+      this.db.prepare(`SELECT COUNT(*) as total FROM analytics_events ${where}`).bind(...params).first() as Promise<{ total: number } | null>,
+      this.db.prepare(`SELECT * FROM analytics_events ${where} ORDER BY created_at DESC LIMIT ? OFFSET ?`).bind(...params, limit, offset).all()
+    ])
+
+    const events = (eventsResult.results || []).map((e: any) => ({
+      ...e,
+      properties: e.properties ? JSON.parse(e.properties) : null
+    }))
+
+    return { events, total: countResult?.total || 0 }
+  }
+
+  async getStats(startDate?: number, endDate?: number): Promise<EventStats> {
+    const conditions: string[] = []
+    const params: any[] = []
+
+    if (startDate) {
+      conditions.push('created_at >= ?')
+      params.push(startDate)
+    }
+    if (endDate) {
+      conditions.push('created_at <= ?')
+      params.push(endDate)
+    }
+
+    const where = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : ''
+
+    const [totals, topEvents] = await Promise.all([
+      this.db.prepare(`
+        SELECT
+          COUNT(*) as total_events,
+          COUNT(DISTINCT user_id) as unique_users,
+          COUNT(DISTINCT session_id) as unique_sessions
+        FROM analytics_events ${where}
+      `).bind(...params).first() as Promise<{ total_events: number; unique_users: number; unique_sessions: number } | null>,
+      this.db.prepare(`
+        SELECT event, COUNT(*) as count
+        FROM analytics_events ${where}
+        GROUP BY event ORDER BY count DESC LIMIT 20
+      `).bind(...params).all()
+    ])
+
+    return {
+      totalEvents: totals?.total_events || 0,
+      uniqueUsers: totals?.unique_users || 0,
+      uniqueSessions: totals?.unique_sessions || 0,
+      topEvents: (topEvents.results || []).map((r: any) => ({ event: r.event, count: r.count }))
+    }
+  }
+}

--- a/packages/core/src/plugins/core-plugins/security-audit-plugin/services/brute-force-detector.ts
+++ b/packages/core/src/plugins/core-plugins/security-audit-plugin/services/brute-force-detector.ts
@@ -22,7 +22,7 @@ export class BruteForceDetector {
     shouldLockEmail: boolean
     isSuspicious: boolean
   }> {
-    if (!this.settings.enabled) {
+    if (!this.settings.enabled || !this.kv) {
       return { ipCount: 0, emailCount: 0, shouldLockIP: false, shouldLockEmail: false, isSuspicious: false }
     }
 
@@ -50,7 +50,7 @@ export class BruteForceDetector {
   }
 
   async isLocked(ip: string, email: string): Promise<{ locked: boolean, reason?: string }> {
-    if (!this.settings.enabled) {
+    if (!this.settings.enabled || !this.kv) {
       return { locked: false }
     }
 
@@ -68,6 +68,7 @@ export class BruteForceDetector {
   }
 
   async lockIP(ip: string): Promise<void> {
+    if (!this.kv) return
     const ttl = this.settings.lockoutDurationMinutes * 60
     await this.kv.put(`${LOCK_PREFIX}ip:${ip}`, JSON.stringify({
       lockedAt: Date.now(),
@@ -76,6 +77,7 @@ export class BruteForceDetector {
   }
 
   async lockEmail(email: string): Promise<void> {
+    if (!this.kv) return
     const ttl = this.settings.lockoutDurationMinutes * 60
     await this.kv.put(`${LOCK_PREFIX}email:${email}`, JSON.stringify({
       lockedAt: Date.now(),
@@ -84,14 +86,17 @@ export class BruteForceDetector {
   }
 
   async unlockIP(ip: string): Promise<void> {
+    if (!this.kv) return
     await this.kv.delete(`${LOCK_PREFIX}ip:${ip}`)
   }
 
   async unlockEmail(email: string): Promise<void> {
+    if (!this.kv) return
     await this.kv.delete(`${LOCK_PREFIX}email:${email}`)
   }
 
   async getActiveLockouts(): Promise<Array<{ key: string, type: 'ip' | 'email', value: string, lockedAt: number }>> {
+    if (!this.kv) return []
     // KV list with prefix to find all active lockouts
     const ipLocks = await this.kv.list({ prefix: `${LOCK_PREFIX}ip:` })
     const emailLocks = await this.kv.list({ prefix: `${LOCK_PREFIX}email:` })
@@ -128,6 +133,7 @@ export class BruteForceDetector {
   }
 
   async releaseLockout(key: string): Promise<void> {
+    if (!this.kv) return
     await this.kv.delete(key)
   }
 


### PR DESCRIPTION
## Summary
- **#785**: BruteForceDetector crashes when `CACHE_KV` binding is missing — added null guards to all KV-dependent methods
- **#787**: Admin analytics sidebar link returns 404 — created admin dashboard route with real system_logs data
- **#788**: All SonicJS routes return 400/403 after v2.15.0 upgrade — fixed CSRF middleware to exempt Bearer-auth and missing auth paths
- **#786**: Add user event tracking API — new `POST /api/events` endpoint with batch support, query/stats endpoints, and migration

## Changes
- `brute-force-detector.ts` — `!this.kv` guards on `isLocked`, `recordFailedAttempt`, `lockIP/Email`, `unlockIP/Email`, `getActiveLockouts`, `releaseLockout`
- `csrf.ts` — Added `/auth/otp`, `/auth/magic-link`, `/auth/verify`, `/api/stripe/webhook`, `/api/events` to exempt paths; skip CSRF when `Authorization` header present
- `analytics/routes/admin.ts` — New admin dashboard querying `system_logs` for request counts, unique IPs, response times, errors, top pages
- `analytics/routes/api.ts` — `POST /api/events` (single + batch), `GET /api/events` (admin query), `GET /api/events/stats` (aggregations)
- `analytics/services/event-tracking-service.ts` — `trackEvent`, `trackBatch`, `queryEvents`, `getStats`
- `036_analytics_events.sql` — New `analytics_events` table with indexes
- `app.ts` — Register analytics plugin routes and events API
- `analytics/index.ts` — Wire admin routes into plugin builder

## Testing
- [x] Unit tests pass locally (1447 passed, 0 failed)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [ ] E2E tests (CI)

## Checklist
- [x] Code follows project conventions
- [x] No new TypeScript errors introduced
- [x] BruteForceDetector follows same guard pattern as rate-limit.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)