### PR TITLE
fix: resolve issues #791, #792

### DIFF
--- a/packages/core/src/app.ts
+++ b/packages/core/src/app.ts
@@ -42,6 +42,7 @@ import { createMagicLinkAuthPlugin } from './plugins/available/magic-link-auth'
 import { securityAuditPlugin } from './plugins/core-plugins/security-audit-plugin'
 import { securityAuditMiddleware } from './plugins/core-plugins/security-audit-plugin'
 import { stripePlugin } from './plugins/core-plugins/stripe-plugin'
+import { requireAuth, requireRole } from './middleware/auth'
 import { pluginMenuMiddleware } from './middleware/plugin-menu'
 import { analyticsPlugin } from './plugins/core-plugins/analytics'
 import { eventsApiRoutes } from './plugins/core-plugins/analytics/routes/api'
@@ -190,6 +191,10 @@ export function createSonicJSApp(config: SonicJSConfig = {}): SonicJSApp {
       app.use('*', middleware)
     }
   }
+
+  // Admin panel: require authentication and admin role
+  app.use('/admin/*', requireAuth())
+  app.use('/admin/*', requireRole(['admin']))
 
   // Plugin dynamic menu items for admin sidebar
   app.use('/admin/*', pluginMenuMiddleware())

--- a/packages/core/src/plugins/core-plugins/stripe-plugin/components/events-page.ts
+++ b/packages/core/src/plugins/core-plugins/stripe-plugin/components/events-page.ts
@@ -62,7 +62,7 @@ export function renderEventsPage(data: EventsPageData): string {
             <tr>
               <th class="px-6 py-3 text-left text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">Time</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">Type</th>
-              <th class="px-6 py-3 text-left text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">Object</th>
+              <th class="px-6 py-3 text-left text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">Object / User</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">Status</th>
               <th class="px-6 py-3 text-left text-xs font-medium text-zinc-500 dark:text-zinc-400 uppercase tracking-wider">Event ID</th>
             </tr>
@@ -127,8 +127,26 @@ function formatTimestamp(timestamp: number): string {
   })
 }
 
+function extractUserInfo(event: StripeEventRecord): { userId?: string; email?: string } {
+  try {
+    const data = typeof event.data === 'string' ? JSON.parse(event.data) : event.data
+    const userId = data?.metadata?.sonicjs_user_id || data?.sonicjs_user_id
+    const email = data?.customer_email || data?.customerEmail || data?.receipt_email
+    return { userId: userId || undefined, email: email || undefined }
+  } catch {
+    return {}
+  }
+}
+
 function renderEventRow(event: StripeEventRecord): string {
   const errorTooltip = event.error ? ` title="${event.error.replace(/"/g, '&quot;')}"` : ''
+  const userInfo = extractUserInfo(event)
+  const userLink = userInfo.userId
+    ? `<a href="/admin/users/${userInfo.userId}" class="text-sm text-blue-600 dark:text-blue-400 hover:underline">${userInfo.email || userInfo.userId}</a>`
+    : userInfo.email
+      ? `<span class="text-sm text-zinc-500 dark:text-zinc-400">${userInfo.email}</span>`
+      : ''
+
   return `
     <tr class="hover:bg-zinc-950/[0.025] dark:hover:bg-white/[0.025]"${errorTooltip}>
       <td class="px-6 py-4 whitespace-nowrap text-sm text-zinc-500 dark:text-zinc-400">
@@ -140,6 +158,7 @@ function renderEventRow(event: StripeEventRecord): string {
       <td class="px-6 py-4 whitespace-nowrap">
         <div class="text-sm font-mono text-zinc-500 dark:text-zinc-400">${event.objectId || '-'}</div>
         <div class="text-xs text-zinc-400 dark:text-zinc-500">${event.objectType}</div>
+        ${userLink ? `<div class="mt-1">${userLink}</div>` : ''}
       </td>
       <td class="px-6 py-4 whitespace-nowrap">${eventStatusBadge(event.status)}</td>
       <td class="px-6 py-4 whitespace-nowrap text-xs font-mono text-zinc-400 dark:text-zinc-500">${event.stripeEventId}</td>


### PR DESCRIPTION
## Summary
- **#791**: Restrict admin panel access to admin role by default — adds centralized `requireAuth()` + `requireRole(['admin'])` middleware for all `/admin/*` routes in `app.ts`, so non-admin users are denied access to the admin UI
- **#792**: Link stripe events to user detail pages — parses event `data` JSON to extract `metadata.sonicjs_user_id` and `customer_email`, rendering clickable links to `/admin/users/{userId}` in the events table

## Changes
- `packages/core/src/app.ts` — Added `requireAuth()` and `requireRole(['admin'])` middleware for `/admin/*` routes
- `packages/core/src/plugins/core-plugins/stripe-plugin/components/events-page.ts` — Added `extractUserInfo()` helper, updated `renderEventRow()` to show user links, renamed column header to "Object / User"

## Testing
- [x] TypeScript compiles cleanly
- [x] All 104 middleware tests pass (including 14 RBAC tests)

Closes #791
Closes #792

🤖 Generated with [Claude Code](https://claude.com/claude-code)