### PR TITLE
docs: add governance, LICENSE, and CODEOWNERS for co-maintainer model

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,30 @@
+# SonicJS Code Owners
+#
+# This file defines who must review changes to specific parts of the codebase.
+# Order matters — the last matching pattern wins.
+#
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# Default owners for everything in the repo
+*                                   @lane711 @mmcintosh
+
+# Core package — both maintainers must approve
+/packages/core/                     @lane711 @mmcintosh
+
+# Governance, licensing, and contribution docs — project lead sign-off required
+/LICENSE                            @lane711
+/GOVERNANCE.md                      @lane711
+/CONTRIBUTING.md                    @lane711
+/.github/CODEOWNERS                 @lane711
+/.github/FUNDING.yml                @lane711
+
+# Release and publishing workflows — project lead sign-off required
+/PUBLISHING.md                      @lane711
+/.github/workflows/                 @lane711
+/scripts/                           @lane711 @mmcintosh
+
+# Website and marketing site
+/www/                               @lane711
+
+# Example app
+/my-sonicjs-app/                    @lane711 @mmcintosh

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,3 @@
-github: lane711
+# GitHub Sponsors profiles for SonicJS maintainers.
+# Both maintainers are listed so sponsors can support whichever maintainer they choose.
+github: [lane711, mmcintosh]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,7 @@ Thank you for your interest in contributing to SonicJS!
 ## Quick Links
 
 - **[Full Contributing Guide](https://sonicjs.com/contributing)** - Detailed guide on how to contribute
+- **[Project Governance](./GOVERNANCE.md)** - How decisions are made and who the maintainers are
 - **[Good First Issues](https://github.com/lane711/sonicjs/labels/good%20first%20issue)** - Great starting points for new contributors
 - **[Help Wanted](https://github.com/lane711/sonicjs/labels/help%20wanted)** - Issues where we need community help
 
@@ -68,6 +69,19 @@ Before submitting a PR:
 - [ ] Changes are documented if needed
 - [ ] PR description explains the changes
 - [ ] Related issue is referenced
+- [ ] Commits are signed off (see DCO below)
+
+## Developer Certificate of Origin (DCO)
+
+By contributing to SonicJS, you certify that you wrote the code (or otherwise have the right to submit it) and agree to release it under the project's MIT license. This is formalized by the [Developer Certificate of Origin](https://developercertificate.org/).
+
+To signal your agreement, add a `Signed-off-by` line to each commit:
+
+```bash
+git commit -s -m "your commit message"
+```
+
+This appends a line like `Signed-off-by: Your Name <your.email@example.com>` to the commit message using your configured `user.name` and `user.email`.
 
 ## Questions?
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,0 +1,98 @@
+# SonicJS Governance
+
+This document describes how decisions are made in the SonicJS project.
+
+## Governance Model
+
+SonicJS follows a **Benevolent Dictator for Life (BDFL)** model with trusted co-maintainers. The project lead has final authority on project direction, but day-to-day development is a shared responsibility among maintainers.
+
+This model is intentionally lightweight. As the project and contributor base grow, we may adopt more formal structures (e.g., a Technical Steering Committee).
+
+## Roles
+
+### Project Lead (BDFL)
+
+- **Current:** [@lane711](https://github.com/lane711) (Lane Campbell)
+- Has final authority on all project decisions
+- Owns the GitHub organization and related infrastructure
+- Sets the project roadmap and long-term vision
+- Can grant or revoke maintainer access
+
+### Maintainers
+
+- **Current:** [@lane711](https://github.com/lane711), [@mmcintosh](https://github.com/mmcintosh)
+- Hold the GitHub "Maintain" role on the repository
+- Can review, approve, and merge pull requests
+- Triage issues and respond to community questions
+- Help cut releases and maintain the changelog
+- Expected to follow the decision-making process below
+
+### Contributors
+
+- Anyone who submits a pull request, opens an issue, or participates in discussions
+- See [CONTRIBUTING.md](./CONTRIBUTING.md) for how to get involved
+
+## Decision-Making Process
+
+### What Maintainers Can Merge Independently
+
+Maintainers may merge PRs without explicit sign-off from the project lead when the change is:
+
+- A bug fix aligned with existing behavior
+- A documentation improvement
+- A test addition or improvement
+- A dependency update (patch or minor version)
+- A feature already discussed and approved in an issue or discussion
+- A refactor that does not change public APIs
+
+### What Requires Project Lead Sign-Off
+
+The following changes require explicit approval from the project lead:
+
+- **Breaking changes** to public APIs or plugin interfaces
+- **New major features** not previously discussed
+- **Licensing or governance changes** (this file, LICENSE, CONTRIBUTING.md)
+- **Dependency additions** that introduce significant new surface area
+- **Security-sensitive changes** (auth, permissions, secrets handling)
+- **Release versioning decisions** (especially major version bumps)
+- **Changes to the project's scope or direction**
+
+### Disagreements
+
+If maintainers disagree on a change:
+
+1. Discuss it openly in the PR or a GitHub discussion
+2. If consensus is not reached, the project lead has final say
+3. The project lead may delegate decisions on specific areas to maintainers over time
+
+## Becoming a Maintainer
+
+Maintainers are invited by the project lead after sustained, high-quality contribution to the project. There is no formal application process.
+
+Signals that someone is ready for maintainer status:
+
+- Consistent, meaningful contributions over a period of months
+- High-quality code review on others' PRs
+- Good judgment on what fits the project's direction
+- Responsiveness and helpfulness in issues and discussions
+- Trust established with the existing maintainer team
+
+## Inactivity
+
+Maintainers who are inactive for **6+ months** without prior notice may have their maintainer role moved to "emeritus" status. This is not punitive — it reflects the reality that priorities change. Emeritus maintainers can rejoin active status at any time by resuming meaningful contributions.
+
+## Funding and Financial Matters
+
+SonicJS accepts funding through [GitHub Sponsors](https://github.com/sponsors/lane711) and other channels listed in [.github/FUNDING.yml](./.github/FUNDING.yml).
+
+Financial arrangements between maintainers (e.g., sponsorship revenue sharing, commercial licensing revenue) are handled privately between the parties involved and are not part of this public governance document.
+
+The project lead retains ownership of the GitHub organization and associated trademarks/brand assets.
+
+## Changes to This Document
+
+Changes to this governance document require approval from the project lead and should be discussed openly with the maintainer team before being merged.
+
+## Questions
+
+For questions about governance, open a [GitHub Discussion](https://github.com/lane711/sonicjs/discussions) or reach out to the project lead.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Lane Campbell and SonicJS contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/core/src/plugins/core-plugins/shortcodes-plugin/index.ts
+++ b/packages/core/src/plugins/core-plugins/shortcodes-plugin/index.ts
@@ -150,6 +150,7 @@ apiRoutes.get('/:id', async (c: any) => {
 apiRoutes.post('/', async (c: any) => {
   try {
     const db = c.env.DB
+    // eslint-disable-next-line @typescript-eslint/naming-convention -- snake_case keys accepted from JSON body for backwards compatibility
     const { name, display_name, displayName, description, handler_key, handlerKey, default_params, defaultParams, example_usage, exampleUsage, category } = await c.req.json()
     const scName = name
     const scHandlerKey = handler_key || handlerKey


### PR DESCRIPTION
## Summary

Formalizes SonicJS governance to support adding a co-maintainer with merge rights. Uses a lightweight BDFL-with-co-maintainer model that is standard for OSS projects at this stage.

- **Adds LICENSE** (MIT) — the repo had no license file, which was a significant legal gap for an open-source project
- **Adds GOVERNANCE.md** — documents the BDFL model, maintainer roles, decision-making split (what can be merged independently vs. what requires project lead sign-off), maintainer inactivity clause, and how new maintainers are added
- **Adds .github/CODEOWNERS** — per-path review requirements; governance/licensing/release paths require the project lead specifically
- **Updates .github/FUNDING.yml** — now supports both `@lane711` and `@mmcintosh` as sponsor targets
- **Updates CONTRIBUTING.md** — adds a governance link and a Developer Certificate of Origin (DCO) sign-off section (lighter-weight than a full CLA)

The first commit (`chore: suppress naming-convention lint error`) is a one-line fix for a pre-existing lint error in the shortcodes plugin that was blocking the pre-commit hook. The snake_case destructuring is intentional (JSON body compat), so it gets an eslint-disable comment rather than a rewrite.

## Before merging

- [ ] Confirm `@mmcintosh` is the correct GitHub handle
- [ ] Confirm copyright line in `LICENSE` ("Lane Campbell and SonicJS contributors, 2024")
- [ ] Verify `@mmcintosh` has (or will set up) a GitHub Sponsors profile for the FUNDING.yml entry to display

## After merging

Manual steps (see `.context/MAINTAINER_SETUP.md` in the workspace for the full checklist):

1. Configure branch protection on `main` (require PR reviews, require Code Owners review, require status checks)
2. Add `@mmcintosh` to the SonicJs-Org organization
3. Grant `@mmcintosh` the **Maintain** role on the repository (not Admin)
4. Have the private conversation with `@mmcintosh` about financial arrangements (sponsorship splits, future licensing, etc.)

## What's intentionally NOT in this PR

- No CLA — DCO is sufficient for a trusted known contributor; revisit if dual-licensing or selling is ever on the table
- No LLC formation — premature until there's meaningful revenue
- No TSC / formal steering committee — overkill for a 2-person maintainer team
- No Open Collective setup — can be added later when sponsorship revenue justifies the 10% fiscal hosting fee

## Test plan

- [x] Pre-commit hooks pass (lint, type-check, tests)
- [ ] CI checks pass on PR
- [ ] FUNDING.yml renders correctly on the repo's Sponsor button
- [ ] CODEOWNERS syntax accepted by GitHub (verify no warnings in the PR "Files changed" tab)

🤖 Generated with [Claude Code](https://claude.com/claude-code)